### PR TITLE
ブックマーク・フォルダの右クリックコンテキストメニュー (#48)

### DIFF
--- a/src/components/BookmarkFolder/BookmarkFolderEvents.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderEvents.ts
@@ -1,6 +1,7 @@
 import { findFolderById } from '../../scripts/utils.js';
-import type { BookmarkFolder } from '../../types/bookmark.js';
+import type { BookmarkFolder, BookmarkItem } from '../../types/bookmark.js';
 import { BookmarkActions } from '../BookmarkActions/index.js';
+import { ContextMenu, type ContextMenuItem } from '../ContextMenu/index.js';
 
 /**
  * ブックマークフォルダーのイベント処理を担当するクラス
@@ -8,9 +9,13 @@ import { BookmarkActions } from '../BookmarkActions/index.js';
 export class BookmarkFolderEvents {
   private bookmarkActions: BookmarkActions;
   private clickHandler: ((e: Event) => void) | null = null;
+  private contextMenuHandler: ((e: Event) => void) | null = null;
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
+  private contextMenu: ContextMenu;
 
   constructor() {
     this.bookmarkActions = new BookmarkActions();
+    this.contextMenu = new ContextMenu();
   }
 
   /**
@@ -57,6 +62,301 @@ export class BookmarkFolderEvents {
 
     // イベントリスナーを登録
     container.addEventListener('click', this.clickHandler);
+
+    // コンテキストメニューのイベントリスナーを設定
+    this.setupContextMenuHandler(container, allBookmarks);
+  }
+
+  /**
+   * 右クリック・Shift+F10 によるコンテキストメニュー表示を設定する
+   */
+  private setupContextMenuHandler(
+    container: HTMLElement,
+    allBookmarks: BookmarkFolder[]
+  ): void {
+    if (this.contextMenuHandler) {
+      container.removeEventListener('contextmenu', this.contextMenuHandler);
+    }
+    if (this.keydownHandler) {
+      container.removeEventListener('keydown', this.keydownHandler);
+    }
+
+    this.contextMenuHandler = (e: Event) => {
+      const mouseEvent = e as MouseEvent;
+      const target = mouseEvent.target as HTMLElement;
+
+      const bookmarkItem = target.closest(
+        '.bookmark-item'
+      ) as HTMLElement | null;
+      const folderHeader = target.closest(
+        '.folder-header'
+      ) as HTMLElement | null;
+
+      if (bookmarkItem) {
+        mouseEvent.preventDefault();
+        this.openBookmarkContextMenu(
+          mouseEvent.clientX,
+          mouseEvent.clientY,
+          bookmarkItem
+        );
+      } else if (folderHeader) {
+        mouseEvent.preventDefault();
+        this.openFolderContextMenu(
+          mouseEvent.clientX,
+          mouseEvent.clientY,
+          folderHeader,
+          allBookmarks
+        );
+      }
+    };
+
+    this.keydownHandler = (e: KeyboardEvent) => {
+      const isMenuKey =
+        e.key === 'ContextMenu' || (e.shiftKey && e.key === 'F10');
+      if (!isMenuKey) return;
+
+      const target = e.target as HTMLElement;
+      const bookmarkItem = target.closest(
+        '.bookmark-item'
+      ) as HTMLElement | null;
+      const folderHeader = target.closest(
+        '.folder-header'
+      ) as HTMLElement | null;
+
+      const activeElement = (bookmarkItem ??
+        folderHeader) as HTMLElement | null;
+      if (!activeElement) return;
+
+      e.preventDefault();
+      const rect = activeElement.getBoundingClientRect();
+      const x = rect.left + 8;
+      const y = rect.bottom;
+
+      if (bookmarkItem) {
+        this.openBookmarkContextMenu(x, y, bookmarkItem);
+      } else if (folderHeader) {
+        this.openFolderContextMenu(x, y, folderHeader, allBookmarks);
+      }
+    };
+
+    container.addEventListener('contextmenu', this.contextMenuHandler);
+    container.addEventListener('keydown', this.keydownHandler);
+  }
+
+  /**
+   * ブックマーク用コンテキストメニューを開く
+   */
+  private openBookmarkContextMenu(
+    x: number,
+    y: number,
+    bookmarkItem: HTMLElement
+  ): void {
+    const link = bookmarkItem.querySelector(
+      '.bookmark-link'
+    ) as HTMLElement | null;
+    const editBtn = bookmarkItem.querySelector(
+      '.bookmark-edit-btn'
+    ) as HTMLElement | null;
+    const deleteBtn = bookmarkItem.querySelector(
+      '.bookmark-delete-btn'
+    ) as HTMLElement | null;
+
+    const url = link?.getAttribute('data-url') ?? '';
+    const title =
+      editBtn?.getAttribute('data-bookmark-title') ??
+      bookmarkItem.querySelector('.bookmark-title')?.textContent?.trim() ??
+      '';
+
+    if (!url) {
+      return;
+    }
+
+    const items: ContextMenuItem[] = [
+      {
+        label: '開く',
+        icon: '🔗',
+        onSelect: () => {
+          chrome.tabs.update({ url });
+        },
+      },
+      {
+        label: '新しいタブで開く',
+        icon: '🆕',
+        onSelect: () => {
+          chrome.tabs.create({ url, active: true });
+        },
+      },
+      {
+        label: 'バックグラウンドで開く',
+        icon: '↗️',
+        onSelect: () => {
+          chrome.tabs.create({ url, active: false });
+        },
+      },
+      {
+        label: 'URLをコピー',
+        icon: '📋',
+        separatorBefore: true,
+        onSelect: async () => {
+          await this.copyToClipboard(url, title);
+        },
+      },
+      {
+        label: '編集',
+        icon: '✏️',
+        separatorBefore: true,
+        disabled: !editBtn,
+        onSelect: () => {
+          if (editBtn) {
+            this.bookmarkActions.handleEdit(editBtn);
+          }
+        },
+      },
+      {
+        label: '削除',
+        icon: '🗑️',
+        disabled: !deleteBtn,
+        onSelect: () => {
+          if (deleteBtn) {
+            this.bookmarkActions.handleDelete(deleteBtn);
+          }
+        },
+      },
+    ];
+
+    this.contextMenu.open(x, y, items);
+  }
+
+  /**
+   * フォルダ用コンテキストメニューを開く
+   */
+  private openFolderContextMenu(
+    x: number,
+    y: number,
+    folderHeader: HTMLElement,
+    allBookmarks: BookmarkFolder[]
+  ): void {
+    const folderElement = folderHeader.closest(
+      '.bookmark-folder'
+    ) as HTMLElement | null;
+    const folderId = folderElement?.getAttribute('data-folder-id');
+    if (!folderId || !folderElement) {
+      return;
+    }
+
+    const folder = this.findFolder(allBookmarks, folderId);
+    if (!folder) {
+      return;
+    }
+
+    const allUrls = this.collectAllBookmarkUrls(folder);
+    const hasBookmarks = allUrls.length > 0;
+    const isExpandable =
+      folder.subfolders.length > 0 || folder.bookmarks.length > 0;
+
+    const items: ContextMenuItem[] = [
+      {
+        label: folder.expanded ? '折りたたむ' : '展開する',
+        icon: folder.expanded ? '📁' : '📂',
+        disabled: !isExpandable,
+        onSelect: () => {
+          this.toggleFolder(folder, folderHeader, folderElement, allBookmarks);
+        },
+      },
+      {
+        label: `中のブックマークを全て新しいタブで開く (${allUrls.length})`,
+        icon: '🆕',
+        separatorBefore: true,
+        disabled: !hasBookmarks,
+        onSelect: () => {
+          for (const url of allUrls) {
+            chrome.tabs.create({ url, active: false });
+          }
+        },
+      },
+      {
+        label: '新規サブフォルダ',
+        icon: '➕',
+        separatorBefore: true,
+        disabled: true,
+        onSelect: () => {
+          console.warn('新規サブフォルダ機能は別 issue (#51) で実装予定です');
+        },
+      },
+      {
+        label: 'フォルダ名を変更',
+        icon: '✏️',
+        disabled: true,
+        onSelect: () => {
+          console.warn('フォルダリネーム機能は別 issue (#52) で実装予定です');
+        },
+      },
+      {
+        label: 'フォルダを削除',
+        icon: '🗑️',
+        disabled: true,
+        onSelect: () => {
+          console.warn('フォルダ削除機能は別 issue (#53) で実装予定です');
+        },
+      },
+    ];
+
+    this.contextMenu.open(x, y, items);
+  }
+
+  /**
+   * フォルダの展開状態を切り替える
+   */
+  private toggleFolder(
+    folder: BookmarkFolder,
+    folderHeader: HTMLElement,
+    folderElement: HTMLElement,
+    allBookmarks: BookmarkFolder[]
+  ): void {
+    if (folder.subfolders.length > 0) {
+      this.toggleFolderWithSubfolders(
+        folder,
+        folderHeader,
+        folderElement,
+        allBookmarks
+      );
+    } else if (folder.bookmarks.length > 0) {
+      this.toggleFolderWithBookmarks(folder, folderHeader, folderElement);
+    }
+  }
+
+  /**
+   * フォルダ内の全ブックマークURLを再帰的に収集する
+   */
+  private collectAllBookmarkUrls(folder: BookmarkFolder): string[] {
+    const urls: string[] = folder.bookmarks.map((b: BookmarkItem) => b.url);
+    for (const sub of folder.subfolders) {
+      urls.push(...this.collectAllBookmarkUrls(sub));
+    }
+    return urls;
+  }
+
+  /**
+   * クリップボードにテキストをコピーする
+   */
+  private async copyToClipboard(url: string, _title: string): Promise<void> {
+    try {
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(url);
+      } else {
+        // フォールバック: 一時的なtextareaを使用
+        const textarea = document.createElement('textarea');
+        textarea.value = url;
+        textarea.style.position = 'fixed';
+        textarea.style.opacity = '0';
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        textarea.remove();
+      }
+    } catch (error) {
+      console.error('❌ URLのコピーに失敗しました:', error);
+    }
   }
 
   /**

--- a/src/components/ContextMenu/index.ts
+++ b/src/components/ContextMenu/index.ts
@@ -1,0 +1,216 @@
+import { escapeHtml } from '../../scripts/utils.js';
+
+export interface ContextMenuItem {
+  label: string;
+  icon?: string;
+  disabled?: boolean;
+  separatorBefore?: boolean;
+  onSelect: () => void | Promise<void>;
+}
+
+const MENU_ID = 'bookmark-context-menu';
+
+/**
+ * 汎用コンテキストメニュー。
+ * 画面上の任意の座標でメニューを開閉し、外側クリック・ESCで閉じる。
+ */
+export class ContextMenu {
+  private currentMenu: HTMLElement | null = null;
+  private onCloseHandler: (() => void) | null = null;
+
+  /**
+   * メニューを開く。すでに別のメニューが開いていれば閉じてから表示する。
+   */
+  open(x: number, y: number, items: ContextMenuItem[]): void {
+    this.close();
+
+    if (items.length === 0) {
+      return;
+    }
+
+    const menu = this.createMenuElement(items);
+    document.body.appendChild(menu);
+
+    // 画面端での見切れを防ぐため、表示後に位置を補正
+    this.positionMenu(menu, x, y);
+
+    this.currentMenu = menu;
+    this.attachItemHandlers(menu, items);
+    this.attachGlobalHandlers();
+
+    // 最初の有効な項目にフォーカス
+    const firstEnabled = menu.querySelector<HTMLElement>(
+      '.context-menu-item:not(.disabled)'
+    );
+    firstEnabled?.focus();
+  }
+
+  /**
+   * メニューが開いていれば閉じる。
+   */
+  close(): void {
+    if (this.currentMenu) {
+      this.currentMenu.remove();
+      this.currentMenu = null;
+    }
+    if (this.onCloseHandler) {
+      this.onCloseHandler();
+      this.onCloseHandler = null;
+    }
+  }
+
+  /**
+   * メニューが開いているかどうか。
+   */
+  isOpen(): boolean {
+    return this.currentMenu !== null;
+  }
+
+  private createMenuElement(items: ContextMenuItem[]): HTMLElement {
+    const menu = document.createElement('div');
+    menu.id = MENU_ID;
+    menu.className = 'context-menu';
+    menu.setAttribute('role', 'menu');
+    menu.innerHTML = items
+      .map((item, index) => this.renderItem(item, index))
+      .join('');
+    return menu;
+  }
+
+  private renderItem(item: ContextMenuItem, index: number): string {
+    if (item.separatorBefore && index > 0) {
+      return `
+        <div class="context-menu-separator" role="separator"></div>
+        ${this.renderItemButton(item, index)}
+      `;
+    }
+    return this.renderItemButton(item, index);
+  }
+
+  private renderItemButton(item: ContextMenuItem, index: number): string {
+    const disabledAttr = item.disabled ? 'disabled' : '';
+    const disabledClass = item.disabled ? 'disabled' : '';
+    const icon = item.icon
+      ? `<span class="context-menu-icon">${escapeHtml(item.icon)}</span>`
+      : '';
+    return `
+      <button type="button"
+              class="context-menu-item ${disabledClass}"
+              role="menuitem"
+              data-index="${index}"
+              ${disabledAttr}>
+        ${icon}
+        <span class="context-menu-label">${escapeHtml(item.label)}</span>
+      </button>
+    `;
+  }
+
+  private positionMenu(menu: HTMLElement, x: number, y: number): void {
+    menu.style.position = 'fixed';
+    menu.style.left = `${x}px`;
+    menu.style.top = `${y}px`;
+    menu.style.visibility = 'hidden';
+
+    // 一旦DOMに付与した状態でサイズを計測
+    requestAnimationFrame(() => {
+      const rect = menu.getBoundingClientRect();
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+
+      let finalX = x;
+      let finalY = y;
+
+      if (x + rect.width > vw) {
+        finalX = Math.max(0, vw - rect.width - 4);
+      }
+      if (y + rect.height > vh) {
+        finalY = Math.max(0, vh - rect.height - 4);
+      }
+
+      menu.style.left = `${finalX}px`;
+      menu.style.top = `${finalY}px`;
+      menu.style.visibility = 'visible';
+    });
+  }
+
+  private attachItemHandlers(
+    menu: HTMLElement,
+    items: ContextMenuItem[]
+  ): void {
+    const buttons =
+      menu.querySelectorAll<HTMLButtonElement>('.context-menu-item');
+    for (const btn of buttons) {
+      btn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        const indexAttr = btn.getAttribute('data-index');
+        if (indexAttr === null) return;
+        const index = Number.parseInt(indexAttr, 10);
+        const item = items[index];
+        if (!item || item.disabled) return;
+        this.close();
+        // メニューを閉じた後にアクションを実行
+        Promise.resolve(item.onSelect()).catch((err) => {
+          console.error('❌ コンテキストメニューアクションの実行に失敗:', err);
+        });
+      });
+    }
+  }
+
+  private attachGlobalHandlers(): void {
+    const handleDocumentClick = (e: MouseEvent) => {
+      if (!this.currentMenu) return;
+      if (!this.currentMenu.contains(e.target as Node)) {
+        this.close();
+      }
+    };
+    const handleKeydown = (e: KeyboardEvent) => {
+      if (!this.currentMenu) return;
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        this.close();
+        return;
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        this.moveFocus(e.key === 'ArrowDown' ? 1 : -1);
+      }
+    };
+    const handleContextMenu = (e: MouseEvent) => {
+      if (!this.currentMenu) return;
+      if (!this.currentMenu.contains(e.target as Node)) {
+        this.close();
+      }
+    };
+    const handleScroll = () => {
+      this.close();
+    };
+
+    // mousedownを使うのは、click時の閉じ漏れを防ぐため
+    document.addEventListener('mousedown', handleDocumentClick, true);
+    document.addEventListener('keydown', handleKeydown);
+    document.addEventListener('contextmenu', handleContextMenu, true);
+    window.addEventListener('scroll', handleScroll, true);
+
+    this.onCloseHandler = () => {
+      document.removeEventListener('mousedown', handleDocumentClick, true);
+      document.removeEventListener('keydown', handleKeydown);
+      document.removeEventListener('contextmenu', handleContextMenu, true);
+      window.removeEventListener('scroll', handleScroll, true);
+    };
+  }
+
+  private moveFocus(delta: number): void {
+    if (!this.currentMenu) return;
+    const items = Array.from(
+      this.currentMenu.querySelectorAll<HTMLElement>(
+        '.context-menu-item:not(.disabled)'
+      )
+    );
+    if (items.length === 0) return;
+    const active = document.activeElement as HTMLElement | null;
+    const currentIndex = active ? items.indexOf(active) : -1;
+    const nextIndex = (currentIndex + delta + items.length) % items.length;
+    items[nextIndex]?.focus();
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1303,3 +1303,66 @@ header h1 {
     gap: 2px;
   }
 }
+
+/* =========================================================================
+   コンテキストメニュー
+   ========================================================================= */
+.context-menu {
+  position: fixed;
+  min-width: 220px;
+  background: var(--surface);
+  border: 1px solid var(--border, rgba(0, 0, 0, 0.08));
+  border-radius: 10px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  padding: 6px;
+  z-index: 10000;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  font-size: 14px;
+  color: var(--text);
+  user-select: none;
+}
+
+.context-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  background: transparent;
+  border: none;
+  padding: 8px 12px;
+  border-radius: 6px;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font-size: inherit;
+  font-family: inherit;
+}
+
+.context-menu-item:hover:not(.disabled),
+.context-menu-item:focus:not(.disabled) {
+  background: var(--accent-soft);
+  outline: none;
+}
+
+.context-menu-item.disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.context-menu-icon {
+  width: 18px;
+  display: inline-flex;
+  justify-content: center;
+}
+
+.context-menu-label {
+  flex: 1;
+}
+
+.context-menu-separator {
+  height: 1px;
+  background: var(--border, rgba(0, 0, 0, 0.08));
+  margin: 4px 2px;
+}

--- a/test/bookmark-context-menu.test.ts
+++ b/test/bookmark-context-menu.test.ts
@@ -1,0 +1,219 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BookmarkFolderEvents } from '../src/components/BookmarkFolder/BookmarkFolderEvents';
+import { BookmarkFolderRenderer } from '../src/components/BookmarkFolder/BookmarkFolderRenderer';
+import type { BookmarkFolder } from '../src/types/bookmark';
+
+describe('右クリックコンテキストメニュー統合', () => {
+  let dom: JSDOM;
+  let container: HTMLElement;
+  let events: BookmarkFolderEvents;
+  let allBookmarks: BookmarkFolder[];
+
+  beforeEach(() => {
+    dom = new JSDOM(
+      `<!DOCTYPE html><html><body><div id="bookmarks"></div></body></html>`,
+      { url: 'chrome-extension://test/newtab.html' }
+    );
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      value: (cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      },
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { clipboard: { writeText: vi.fn().mockResolvedValue(undefined) } },
+      writable: true,
+      configurable: true,
+    });
+
+    const mockChrome = globalThis.chrome as unknown as {
+      tabs: {
+        create: ReturnType<typeof vi.fn>;
+        update: ReturnType<typeof vi.fn>;
+      };
+    };
+    mockChrome.tabs.create = vi.fn();
+    mockChrome.tabs.update = vi.fn();
+
+    allBookmarks = [
+      {
+        id: 'folder-1',
+        title: 'テストフォルダ',
+        expanded: true,
+        bookmarks: [
+          {
+            title: 'サイトA',
+            url: 'https://a.example.com',
+            favicon: null,
+          },
+          {
+            title: 'サイトB',
+            url: 'https://b.example.com',
+            favicon: null,
+          },
+        ],
+        subfolders: [],
+      },
+    ];
+
+    container = dom.window.document.getElementById('bookmarks') as HTMLElement;
+    const renderer = new BookmarkFolderRenderer();
+    container.innerHTML = renderer.renderFolders(allBookmarks);
+
+    events = new BookmarkFolderEvents();
+    events.setupFolderClickHandler(container, allBookmarks);
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  function dispatchContextMenu(target: HTMLElement): void {
+    const event = new dom.window.MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 100,
+      clientY: 100,
+    });
+    target.dispatchEvent(event);
+  }
+
+  it('ブックマーク上で右クリックすると編集・削除・開くメニューが表示される', () => {
+    const bookmarkItem = container.querySelector(
+      '.bookmark-item'
+    ) as HTMLElement;
+    dispatchContextMenu(bookmarkItem);
+
+    const menu = document.getElementById('bookmark-context-menu');
+    expect(menu).not.toBeNull();
+
+    const labels = Array.from(
+      menu?.querySelectorAll('.context-menu-label') ?? []
+    ).map((el) => el.textContent);
+
+    expect(labels).toContain('開く');
+    expect(labels).toContain('新しいタブで開く');
+    expect(labels).toContain('URLをコピー');
+    expect(labels).toContain('編集');
+    expect(labels).toContain('削除');
+  });
+
+  it('「新しいタブで開く」を選択すると chrome.tabs.create が呼ばれる', () => {
+    const bookmarkItem = container.querySelector(
+      '.bookmark-item'
+    ) as HTMLElement;
+    dispatchContextMenu(bookmarkItem);
+
+    const buttons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.context-menu-item')
+    );
+    const newTabBtn = buttons.find((b) =>
+      b.textContent?.includes('新しいタブで開く')
+    );
+    newTabBtn?.click();
+
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: 'https://a.example.com',
+      active: true,
+    });
+  });
+
+  it('フォルダヘッダー上で右クリックするとフォルダメニューが表示される', () => {
+    const folderHeader = container.querySelector(
+      '.folder-header'
+    ) as HTMLElement;
+    dispatchContextMenu(folderHeader);
+
+    const menu = document.getElementById('bookmark-context-menu');
+    expect(menu).not.toBeNull();
+
+    const labels = Array.from(
+      menu?.querySelectorAll('.context-menu-label') ?? []
+    ).map((el) => el.textContent);
+
+    expect(
+      labels.some((l) => l?.includes('折りたたむ') || l?.includes('展開する'))
+    ).toBe(true);
+    expect(labels.some((l) => l?.includes('全て新しいタブで開く'))).toBe(true);
+    expect(labels).toContain('新規サブフォルダ');
+    expect(labels).toContain('フォルダ名を変更');
+    expect(labels).toContain('フォルダを削除');
+  });
+
+  it('フォルダの未実装メニュー項目は disabled になっている', () => {
+    const folderHeader = container.querySelector(
+      '.folder-header'
+    ) as HTMLElement;
+    dispatchContextMenu(folderHeader);
+
+    const buttons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.context-menu-item')
+    );
+    const rename = buttons.find((b) =>
+      b.textContent?.includes('フォルダ名を変更')
+    );
+    const remove = buttons.find((b) =>
+      b.textContent?.includes('フォルダを削除')
+    );
+    const newSub = buttons.find((b) =>
+      b.textContent?.includes('新規サブフォルダ')
+    );
+
+    expect(rename?.disabled).toBe(true);
+    expect(remove?.disabled).toBe(true);
+    expect(newSub?.disabled).toBe(true);
+  });
+
+  it('「中のブックマークを全て新しいタブで開く」を選択すると全URLが開かれる', () => {
+    const folderHeader = container.querySelector(
+      '.folder-header'
+    ) as HTMLElement;
+    dispatchContextMenu(folderHeader);
+
+    const buttons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.context-menu-item')
+    );
+    const openAll = buttons.find((b) =>
+      b.textContent?.includes('全て新しいタブで開く')
+    );
+    openAll?.click();
+
+    expect(chrome.tabs.create).toHaveBeenCalledTimes(2);
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: 'https://a.example.com',
+      active: false,
+    });
+    expect(chrome.tabs.create).toHaveBeenCalledWith({
+      url: 'https://b.example.com',
+      active: false,
+    });
+  });
+
+  it('右クリック時にデフォルトのコンテキストメニューが抑制される', () => {
+    const bookmarkItem = container.querySelector(
+      '.bookmark-item'
+    ) as HTMLElement;
+    const event = new dom.window.MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+    });
+    bookmarkItem.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/test/context-menu.test.ts
+++ b/test/context-menu.test.ts
@@ -1,0 +1,128 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ContextMenu } from '../src/components/ContextMenu/index';
+
+describe('ContextMenu', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+      url: 'chrome-extension://test/newtab.html',
+    });
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      value: (cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('open() でメニューがDOMに追加される', () => {
+    const menu = new ContextMenu();
+    menu.open(10, 20, [
+      { label: '項目1', onSelect: vi.fn() },
+      { label: '項目2', onSelect: vi.fn() },
+    ]);
+
+    const el = document.getElementById('bookmark-context-menu');
+    expect(el).not.toBeNull();
+    expect(el?.querySelectorAll('.context-menu-item').length).toBe(2);
+  });
+
+  it('項目クリックで onSelect が呼ばれメニューが閉じる', () => {
+    const menu = new ContextMenu();
+    const handler = vi.fn();
+    menu.open(0, 0, [{ label: '実行', onSelect: handler }]);
+
+    const button = document.querySelector(
+      '.context-menu-item'
+    ) as HTMLButtonElement;
+    button.click();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(menu.isOpen()).toBe(false);
+  });
+
+  it('disabled 項目クリックでは onSelect が呼ばれない', () => {
+    const menu = new ContextMenu();
+    const handler = vi.fn();
+    menu.open(0, 0, [{ label: '無効', disabled: true, onSelect: handler }]);
+
+    const button = document.querySelector(
+      '.context-menu-item'
+    ) as HTMLButtonElement;
+    button.click();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('ESCキーでメニューが閉じる', () => {
+    const menu = new ContextMenu();
+    menu.open(0, 0, [{ label: '項目', onSelect: vi.fn() }]);
+
+    expect(menu.isOpen()).toBe(true);
+
+    const event = new dom.window.KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+
+    expect(menu.isOpen()).toBe(false);
+  });
+
+  it('メニュー外クリックでメニューが閉じる', () => {
+    const menu = new ContextMenu();
+    menu.open(0, 0, [{ label: '項目', onSelect: vi.fn() }]);
+
+    expect(menu.isOpen()).toBe(true);
+
+    const outside = document.body;
+    const event = new dom.window.MouseEvent('mousedown', { bubbles: true });
+    outside.dispatchEvent(event);
+
+    expect(menu.isOpen()).toBe(false);
+  });
+
+  it('再度 open() を呼ぶと以前のメニューが置き換わる', () => {
+    const menu = new ContextMenu();
+    menu.open(0, 0, [{ label: 'A', onSelect: vi.fn() }]);
+    menu.open(0, 0, [{ label: 'B', onSelect: vi.fn() }]);
+
+    const elements = document.querySelectorAll('#bookmark-context-menu');
+    expect(elements.length).toBe(1);
+    expect(elements[0].textContent).toContain('B');
+  });
+
+  it('空の項目配列ではメニューを開かない', () => {
+    const menu = new ContextMenu();
+    menu.open(0, 0, []);
+    expect(menu.isOpen()).toBe(false);
+  });
+
+  it('separatorBefore でセパレータが描画される', () => {
+    const menu = new ContextMenu();
+    menu.open(0, 0, [
+      { label: 'A', onSelect: vi.fn() },
+      { label: 'B', separatorBefore: true, onSelect: vi.fn() },
+    ]);
+
+    const separators = document.querySelectorAll('.context-menu-separator');
+    expect(separators.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- 汎用 `ContextMenu` コンポーネントを新規追加し、ブックマーク・フォルダ上での右クリックメニューを実装
- ブックマーク右クリック: 開く / 新しいタブで開く / バックグラウンドで開く / URLをコピー / 編集 / 削除
- フォルダ右クリック: 展開・折りたたみ / 中のブックマークを全て新タブで開く（再帰）
- フォルダのリネーム・削除・新規サブフォルダはメニュー項目だけ用意し disabled。実装は別 issue #51 / #52 / #53 で対応
- メニュー外クリック・ESC・スクロール・別のメニュー起動で自動クローズ
- 矢印キーでの項目間移動、Shift+F10 / ContextMenu キーでの起動に対応

## 既存挙動への影響
- 既存のホバー表示の編集・削除ボタン (`✏️` / `🗑️`) はそのまま温存（a11y issue #58 で扱う）
- 既存の左クリック・DnD・タブ切替の挙動は変更なし

## Test plan
- [x] `npm test` （129 tests passed）
- [x] `npm run lint` （変更ファイルのみ。`coverage/` 配下の既存警告は範囲外）
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機でブックマークを右クリックして各メニュー項目の挙動を確認
- [x] 実機でフォルダを右クリックして「中のブックマークを全て新タブで開く」が再帰的にURLを開くことを確認
- [x] 実機でメニュー外クリック・ESC でメニューが閉じることを確認

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)