### PR TITLE
ブックマーク削除・移動の Undo 機能 (#46)

### DIFF
--- a/src/components/BookmarkActions/BookmarkDeleter.ts
+++ b/src/components/BookmarkActions/BookmarkDeleter.ts
@@ -1,4 +1,5 @@
 import { escapeHtml } from '../../scripts/utils.js';
+import { UndoManager } from '../UndoManager/index.js';
 
 /**
  * ブックマーク削除機能を担当するクラス
@@ -24,15 +25,50 @@ export class BookmarkDeleter {
     }
 
     try {
-      // Chrome APIを使用してブックマークを削除
-      await this.deleteBookmarkByUrl(url);
+      // Undo に必要な情報を削除前に取得
+      const bookmarks = await chrome.bookmarks.search({ url });
+      if (bookmarks.length === 0) {
+        throw new Error('削除対象のブックマークが見つかりませんでした');
+      }
+      const target = bookmarks[0];
+      const restoreInfo = {
+        parentId: target.parentId,
+        index: target.index,
+        title: target.title,
+        url: target.url,
+      };
 
-      // 削除後、ページを再読み込みして表示を更新
-      window.location.reload();
+      // Chrome APIを使用してブックマークを削除
+      await chrome.bookmarks.remove(target.id);
+
+      // UI を更新するイベントを発火
+      this.dispatchBookmarksChanged('delete');
+
+      // Undo 可能な操作として登録
+      UndoManager.getInstance().register({
+        message: `「${title}」を削除しました`,
+        undo: async () => {
+          await chrome.bookmarks.create({
+            parentId: restoreInfo.parentId,
+            index: restoreInfo.index,
+            title: restoreInfo.title,
+            url: restoreInfo.url,
+          });
+          this.dispatchBookmarksChanged('undo-delete');
+        },
+      });
     } catch (error) {
       console.error('❌ ブックマークの削除に失敗しました:', error);
       this.showErrorDialog('ブックマークの削除に失敗しました。');
     }
+  }
+
+  /**
+   * ブックマーク変更通知イベントを発火する
+   */
+  private dispatchBookmarksChanged(action: string): void {
+    const event = new CustomEvent('bookmarks-changed', { detail: { action } });
+    document.dispatchEvent(event);
   }
 
   /**
@@ -188,19 +224,5 @@ export class BookmarkDeleter {
       }
     };
     document.addEventListener('keydown', handleKeydown);
-  }
-
-  /**
-   * URLを指定してブックマークを削除する
-   */
-  private async deleteBookmarkByUrl(url: string): Promise<void> {
-    const bookmarks = await chrome.bookmarks.search({ url: url });
-
-    if (bookmarks.length === 0) {
-      throw new Error('削除対象のブックマークが見つかりませんでした');
-    }
-
-    // 最初に見つかったブックマークを削除
-    await chrome.bookmarks.remove(bookmarks[0].id);
   }
 }

--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -1,3 +1,5 @@
+import { UndoManager } from '../UndoManager/index.js';
+
 /**
  * ブックマークのドラッグ&ドロップ機能を管理するクラス
  */
@@ -219,6 +221,9 @@ export class BookmarkDragAndDrop {
       }
 
       const bookmark = bookmarks[0];
+      const originalParentId = bookmark.parentId;
+      const originalIndex = bookmark.index;
+      const bookmarkTitle = bookmark.title;
 
       // ブックマークを移動
       await chrome.bookmarks.move(bookmark.id, {
@@ -229,6 +234,23 @@ export class BookmarkDragAndDrop {
         bookmarkId: bookmark.id,
         newParentId: targetFolderId,
       });
+
+      // Undo 可能な操作として登録 (id は move では維持される)
+      if (originalParentId !== undefined) {
+        UndoManager.getInstance().register({
+          message: `「${bookmarkTitle}」を移動しました`,
+          undo: async () => {
+            await chrome.bookmarks.move(bookmark.id, {
+              parentId: originalParentId,
+              index: originalIndex,
+            });
+            const event = new CustomEvent('bookmarks-changed', {
+              detail: { action: 'undo-move' },
+            });
+            document.dispatchEvent(event);
+          },
+        });
+      }
     } catch (error) {
       console.error('Chrome Bookmarks API エラー:', error);
       throw error;

--- a/src/components/Toast/index.ts
+++ b/src/components/Toast/index.ts
@@ -1,0 +1,162 @@
+import { escapeHtml } from '../../scripts/utils.js';
+
+export interface ToastAction {
+  label: string;
+  onActivate: () => void | Promise<void>;
+}
+
+export interface ToastOptions {
+  message: string;
+  durationMs?: number;
+  action?: ToastAction;
+}
+
+const TOAST_CONTAINER_ID = 'app-toast-container';
+const DEFAULT_DURATION_MS = 5000;
+
+/**
+ * 画面下部に表示する Toast (スナックバー) コンポーネント。
+ * 同時に表示できるのは 1 件で、新しい Toast は既存の Toast を置き換える。
+ */
+export class Toast {
+  private static currentInstance: Toast | null = null;
+
+  private element: HTMLElement;
+  private timerId: number | null = null;
+  private action: ToastAction | null;
+
+  private constructor(options: ToastOptions) {
+    this.action = options.action ?? null;
+    this.element = this.render(options);
+    this.attachHandlers();
+    this.scheduleAutoClose(options.durationMs ?? DEFAULT_DURATION_MS);
+  }
+
+  /**
+   * Toast を表示する。既存の Toast があれば置き換える。
+   */
+  static show(options: ToastOptions): Toast {
+    Toast.dismissCurrent();
+    const instance = new Toast(options);
+    Toast.currentInstance = instance;
+    return instance;
+  }
+
+  /**
+   * 現在表示中の Toast を閉じる。
+   */
+  static dismissCurrent(): void {
+    Toast.currentInstance?.dismiss();
+  }
+
+  /**
+   * 現在表示中の Toast のアクションを発火させる。Cmd/Ctrl+Z などからの呼び出し用。
+   * アクションを実行できた場合は true を返す。
+   */
+  static async triggerCurrentAction(): Promise<boolean> {
+    const instance = Toast.currentInstance;
+    if (!instance?.action) {
+      return false;
+    }
+    await instance.activateAction();
+    return true;
+  }
+
+  /**
+   * テスト用: 現在のインスタンスを取得する。
+   */
+  static getCurrentInstance(): Toast | null {
+    return Toast.currentInstance;
+  }
+
+  /**
+   * Toast を閉じる。
+   */
+  dismiss(): void {
+    if (this.timerId !== null) {
+      window.clearTimeout(this.timerId);
+      this.timerId = null;
+    }
+    this.element.remove();
+    if (Toast.currentInstance === this) {
+      Toast.currentInstance = null;
+    }
+  }
+
+  /**
+   * アクションが設定されているかどうか。
+   */
+  hasAction(): boolean {
+    return this.action !== null;
+  }
+
+  private async activateAction(): Promise<void> {
+    const action = this.action;
+    if (!action) {
+      return;
+    }
+    // アクション実行中に Toast がクリアされても問題ないように先に dismiss する
+    this.dismiss();
+    try {
+      await action.onActivate();
+    } catch (error) {
+      console.error('❌ Toast アクションの実行に失敗:', error);
+    }
+  }
+
+  private render(options: ToastOptions): HTMLElement {
+    const container = this.ensureContainer();
+
+    const toast = document.createElement('div');
+    toast.className = 'app-toast';
+    toast.setAttribute('role', 'status');
+    toast.setAttribute('aria-live', 'polite');
+
+    const actionHtml = options.action
+      ? `<button type="button" class="app-toast-action">${escapeHtml(
+          options.action.label
+        )}</button>`
+      : '';
+
+    toast.innerHTML = `
+      <span class="app-toast-message">${escapeHtml(options.message)}</span>
+      ${actionHtml}
+      <button type="button" class="app-toast-close" aria-label="閉じる">×</button>
+    `;
+
+    container.appendChild(toast);
+    return toast;
+  }
+
+  private ensureContainer(): HTMLElement {
+    let container = document.getElementById(TOAST_CONTAINER_ID);
+    if (!container) {
+      container = document.createElement('div');
+      container.id = TOAST_CONTAINER_ID;
+      container.className = 'app-toast-container';
+      document.body.appendChild(container);
+    }
+    return container;
+  }
+
+  private attachHandlers(): void {
+    const actionBtn =
+      this.element.querySelector<HTMLButtonElement>('.app-toast-action');
+    actionBtn?.addEventListener('click', () => {
+      void this.activateAction();
+    });
+
+    const closeBtn =
+      this.element.querySelector<HTMLButtonElement>('.app-toast-close');
+    closeBtn?.addEventListener('click', () => {
+      this.dismiss();
+    });
+  }
+
+  private scheduleAutoClose(durationMs: number): void {
+    if (durationMs <= 0) return;
+    this.timerId = window.setTimeout(() => {
+      this.dismiss();
+    }, durationMs);
+  }
+}

--- a/src/components/UndoManager/index.ts
+++ b/src/components/UndoManager/index.ts
@@ -1,0 +1,113 @@
+import { Toast } from '../Toast/index.js';
+
+export interface UndoableOperation {
+  message: string;
+  undo: () => void | Promise<void>;
+}
+
+/**
+ * 直前の破壊的操作の取り消し (Undo) を管理する。
+ *
+ * 設計判断:
+ * - 深さ 1 の置換方式。新しい操作が来ると古い Undo は破棄される
+ * - 理由: 並べ替えや連続削除を考えると、複数履歴を扱うとIDずれや時系列の整合が複雑化
+ *   して UX が壊れやすい。Chrome ブックマーク API では削除復元時に id が変わるため、
+ *   後続操作が古い id を参照しても無効になる
+ * - Cmd/Ctrl+Z は入力欄や contentEditable にフォーカスがあるときは標準動作を優先する
+ */
+export class UndoManager {
+  private static instance: UndoManager | null = null;
+  private currentUndo: (() => void | Promise<void>) | null = null;
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
+
+  static getInstance(): UndoManager {
+    if (!UndoManager.instance) {
+      UndoManager.instance = new UndoManager();
+    }
+    return UndoManager.instance;
+  }
+
+  /**
+   * グローバルなキーボードハンドラを登録する。アプリ起動時に一度だけ呼ぶ。
+   */
+  initialize(): void {
+    if (this.keydownHandler) {
+      return;
+    }
+    this.keydownHandler = (e: KeyboardEvent) => {
+      const isUndo = (e.metaKey || e.ctrlKey) && !e.shiftKey && e.key === 'z';
+      if (!isUndo) return;
+
+      // 入力欄にフォーカスがある場合は標準動作を優先
+      const active = document.activeElement as HTMLElement | null;
+      if (this.isEditableElement(active)) return;
+
+      if (!this.currentUndo) return;
+
+      e.preventDefault();
+      void this.triggerUndo();
+    };
+    document.addEventListener('keydown', this.keydownHandler);
+  }
+
+  /**
+   * Undo 可能な操作を登録し、Toast に「元に戻す」ボタンを表示する。
+   */
+  register(operation: UndoableOperation): void {
+    const undoFn = operation.undo;
+    this.currentUndo = undoFn;
+    Toast.show({
+      message: operation.message,
+      action: {
+        label: '元に戻す',
+        onActivate: async () => {
+          // クリアしてから実行 (実行中に再登録されても上書きされる)
+          if (this.currentUndo === undoFn) {
+            this.currentUndo = null;
+          }
+          await undoFn();
+        },
+      },
+    });
+  }
+
+  /**
+   * 現在の Undo を実行する。Toast 経由・Cmd+Z 経由の両方から呼ばれる。
+   */
+  async triggerUndo(): Promise<boolean> {
+    const handled = await Toast.triggerCurrentAction();
+    if (!handled && this.currentUndo) {
+      const fn = this.currentUndo;
+      this.currentUndo = null;
+      await fn();
+      return true;
+    }
+    return handled;
+  }
+
+  /**
+   * 現在の Undo をクリアする。
+   */
+  clear(): void {
+    this.currentUndo = null;
+  }
+
+  /**
+   * Undo が利用可能か。
+   */
+  hasUndo(): boolean {
+    return this.currentUndo !== null;
+  }
+
+  private isEditableElement(el: HTMLElement | null): boolean {
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+      return true;
+    }
+    if (el.isContentEditable) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/scripts/newtab.ts
+++ b/src/scripts/newtab.ts
@@ -2,6 +2,7 @@ import { BookmarkDragAndDrop } from '../components/BookmarkDragAndDrop/index.js'
 import { CalendarHistoryPanel } from '../components/CalendarHistoryPanel/index.js';
 import { HistoryPanel } from '../components/HistoryPanel/index.js';
 import { TabController } from '../components/TabController/index.js';
+import { UndoManager } from '../components/UndoManager/index.js';
 import { SELECTORS } from '../constants/index.js';
 import type { BookmarkFolder, ChromeBookmarkNode } from '../types/bookmark.js';
 import { renderFolder, setupFolderClickHandler } from './newtab-core.js';
@@ -68,6 +69,9 @@ document.addEventListener('DOMContentLoaded', async (): Promise<void> => {
   // ドラッグ&ドロップ機能の初期化
   bookmarkDragAndDrop = new BookmarkDragAndDrop();
   bookmarkDragAndDrop.initialize();
+
+  // Undo 機能 (Cmd/Ctrl+Z) の初期化
+  UndoManager.getInstance().initialize();
 
   // ブックマーク変更イベントリスナーを追加
   document.addEventListener('bookmarks-changed', async () => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1305,6 +1305,92 @@ header h1 {
 }
 
 /* =========================================================================
+   Toast (スナックバー)
+   ========================================================================= */
+.app-toast-container {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  z-index: 11000;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.app-toast {
+  pointer-events: auto;
+  background: rgba(31, 36, 51, 0.95);
+  color: #ffffff;
+  border-radius: 10px;
+  padding: 10px 12px 10px 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.32);
+  font-size: 14px;
+  max-width: 480px;
+  animation: app-toast-in 180ms ease-out;
+}
+
+@keyframes app-toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.app-toast-message {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.app-toast-action {
+  background: transparent;
+  color: #c5cfff;
+  border: none;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+}
+
+.app-toast-action:hover,
+.app-toast-action:focus {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+  outline: none;
+}
+
+.app-toast-close {
+  background: transparent;
+  color: rgba(255, 255, 255, 0.7);
+  border: none;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+  padding: 0;
+}
+
+.app-toast-close:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: #ffffff;
+}
    コンテキストメニュー
    ========================================================================= */
 .context-menu {

--- a/test/bookmark-delete.test.ts
+++ b/test/bookmark-delete.test.ts
@@ -22,6 +22,16 @@ describe('ブックマーク削除機能のテスト', () => {
       writable: true,
       configurable: true,
     });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
 
     // Chrome API のモック設定
     const mockChrome = globalThis.chrome as any;
@@ -95,21 +105,24 @@ describe('ブックマーク削除機能のテスト', () => {
     expect(document.getElementById('delete-dialog')).toBeNull();
   });
 
-  it('削除確認でOKを選択した場合はChrome APIを使用して削除処理が実行される', async () => {
+  it('削除確認でOKを選択した場合はChrome APIで削除し bookmarks-changed イベントを発火する', async () => {
     // Chrome API のモック設定
     const mockChrome = globalThis.chrome as any;
     mockChrome.bookmarks.search.mockResolvedValue([
       {
         id: 'bookmark-1',
+        parentId: 'folder-1',
+        index: 2,
         title: 'テストブックマーク',
         url: 'https://example.com',
       },
     ]);
     mockChrome.bookmarks.remove.mockResolvedValue(undefined);
+    mockChrome.bookmarks.create = vi.fn().mockResolvedValue({});
 
-    // location.reload のモック
-    const reloadSpy = vi.fn();
-    globalThis.location = { reload: reloadSpy } as any;
+    // bookmarks-changed イベントを監視
+    const changedSpy = vi.fn();
+    document.addEventListener('bookmarks-changed', changedSpy);
 
     // テスト用の削除ボタン要素を作成
     const deleteBtn = document.createElement('button');
@@ -122,16 +135,11 @@ describe('ブックマーク削除機能のテスト', () => {
     // 少し待ってダイアログが表示されることを確認
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    // 削除ダイアログが表示されていることを確認
-    const dialog = document.getElementById('delete-dialog');
-    expect(dialog).toBeTruthy();
-    expect(dialog?.textContent).toContain('テストブックマーク');
-
     // 確認ボタンをクリック
+    const dialog = document.getElementById('delete-dialog');
     const confirmBtn = dialog?.querySelector(
       '.delete-dialog-confirm'
     ) as HTMLElement;
-    expect(confirmBtn).toBeTruthy();
     confirmBtn.click();
 
     // 削除処理の完了を待機
@@ -142,10 +150,29 @@ describe('ブックマーク削除機能のテスト', () => {
       url: 'https://example.com',
     });
     expect(chrome.bookmarks.remove).toHaveBeenCalledWith('bookmark-1');
-    expect(reloadSpy).toHaveBeenCalled();
 
-    // ダイアログが削除されていることを確認
-    expect(document.getElementById('delete-dialog')).toBeNull();
+    // bookmarks-changed イベントが発火されている
+    expect(changedSpy).toHaveBeenCalled();
+
+    // Undo Toast が表示されている
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toContain('テストブックマーク');
+    expect(toast?.querySelector('.app-toast-action')?.textContent).toContain(
+      '元に戻す'
+    );
+
+    // 「元に戻す」を押すと chrome.bookmarks.create が呼ばれる
+    (toast?.querySelector('.app-toast-action') as HTMLButtonElement).click();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(chrome.bookmarks.create).toHaveBeenCalledWith({
+      parentId: 'folder-1',
+      index: 2,
+      title: 'テストブックマーク',
+      url: 'https://example.com',
+    });
+
+    document.removeEventListener('bookmarks-changed', changedSpy);
   });
 
   it('削除対象のブックマークが見つからない場合はエラーメッセージが表示される', async () => {
@@ -157,10 +184,6 @@ describe('ブックマーク削除機能のテスト', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-
-    // location.reload のモック
-    const reloadSpy = vi.fn();
-    globalThis.location = { reload: reloadSpy } as any;
 
     // テスト用の削除ボタン要素を作成
     const deleteBtn = document.createElement('button');
@@ -196,7 +219,6 @@ describe('ブックマーク削除機能のテスト', () => {
       expect.any(Error)
     );
     expect(chrome.bookmarks.remove).not.toHaveBeenCalled();
-    expect(reloadSpy).not.toHaveBeenCalled();
   });
 
   it('削除処理でエラーが発生した場合はエラーメッセージが表示される', async () => {
@@ -217,10 +239,6 @@ describe('ブックマーク削除機能のテスト', () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')
       .mockImplementation(() => {});
-
-    // location.reload のモック
-    const reloadSpy = vi.fn();
-    globalThis.location = { reload: reloadSpy } as any;
 
     // テスト用の削除ボタン要素を作成
     const deleteBtn = document.createElement('button');
@@ -255,7 +273,6 @@ describe('ブックマーク削除機能のテスト', () => {
       '❌ ブックマークの削除に失敗しました:',
       expect.any(Error)
     );
-    expect(reloadSpy).not.toHaveBeenCalled();
   });
 
   it('URLやタイトルが取得できない場合はエラーメッセージが表示される', async () => {

--- a/test/toast.test.ts
+++ b/test/toast.test.ts
@@ -1,0 +1,111 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Toast } from '../src/components/Toast/index';
+
+describe('Toast', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+      url: 'chrome-extension://test/newtab.html',
+    });
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    Toast.dismissCurrent();
+    vi.useRealTimers();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('show() で Toast がDOMに表示される', () => {
+    Toast.show({ message: 'テストメッセージ' });
+    const el = document.querySelector('.app-toast');
+    expect(el).not.toBeNull();
+    expect(el?.textContent).toContain('テストメッセージ');
+  });
+
+  it('アクション付きで表示するとボタンが描画される', () => {
+    Toast.show({
+      message: 'メッセージ',
+      action: { label: '元に戻す', onActivate: vi.fn() },
+    });
+    const btn = document.querySelector('.app-toast-action');
+    expect(btn).not.toBeNull();
+    expect(btn?.textContent?.trim()).toBe('元に戻す');
+  });
+
+  it('アクションボタンクリックで onActivate が呼ばれ Toast が閉じる', async () => {
+    const handler = vi.fn();
+    Toast.show({
+      message: 'メッセージ',
+      action: { label: '元に戻す', onActivate: handler },
+    });
+
+    const btn = document.querySelector(
+      '.app-toast-action'
+    ) as HTMLButtonElement;
+    btn.click();
+    await vi.runAllTimersAsync();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(document.querySelector('.app-toast')).toBeNull();
+  });
+
+  it('一定時間経過で自動で閉じる', () => {
+    Toast.show({ message: 'メッセージ', durationMs: 3000 });
+    expect(document.querySelector('.app-toast')).not.toBeNull();
+
+    vi.advanceTimersByTime(3000);
+
+    expect(document.querySelector('.app-toast')).toBeNull();
+  });
+
+  it('再度 show() を呼ぶと前の Toast が置き換わる (置換戦略)', () => {
+    Toast.show({ message: '最初' });
+    Toast.show({ message: '次' });
+
+    const toasts = document.querySelectorAll('.app-toast');
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].textContent).toContain('次');
+  });
+
+  it('閉じるボタンで Toast が消える', () => {
+    Toast.show({ message: 'メッセージ' });
+    const closeBtn = document.querySelector(
+      '.app-toast-close'
+    ) as HTMLButtonElement;
+    closeBtn.click();
+    expect(document.querySelector('.app-toast')).toBeNull();
+  });
+
+  it('triggerCurrentAction() でアクションを発火できる', async () => {
+    const handler = vi.fn();
+    Toast.show({
+      message: 'メッセージ',
+      action: { label: '元に戻す', onActivate: handler },
+    });
+
+    const handled = await Toast.triggerCurrentAction();
+    expect(handled).toBe(true);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('アクションがない場合 triggerCurrentAction() は false を返す', async () => {
+    Toast.show({ message: 'メッセージ' });
+    const handled = await Toast.triggerCurrentAction();
+    expect(handled).toBe(false);
+  });
+});

--- a/test/undo-manager.test.ts
+++ b/test/undo-manager.test.ts
@@ -1,0 +1,122 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Toast } from '../src/components/Toast/index';
+import { UndoManager } from '../src/components/UndoManager/index';
+
+describe('UndoManager', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+      url: 'chrome-extension://test/newtab.html',
+    });
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+
+    // シングルトン状態をリセット
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+  });
+
+  afterEach(() => {
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('register() で Toast に「元に戻す」が表示される', () => {
+    UndoManager.getInstance().register({
+      message: '「項目A」を削除しました',
+      undo: vi.fn(),
+    });
+
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toContain('「項目A」を削除しました');
+    expect(toast?.querySelector('.app-toast-action')?.textContent?.trim()).toBe(
+      '元に戻す'
+    );
+  });
+
+  it('「元に戻す」ボタンクリックで undo が呼ばれる', async () => {
+    const undoFn = vi.fn();
+    UndoManager.getInstance().register({
+      message: 'メッセージ',
+      undo: undoFn,
+    });
+
+    const btn = document.querySelector(
+      '.app-toast-action'
+    ) as HTMLButtonElement;
+    btn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(undoFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('新しい register で前の Undo が置き換わる', () => {
+    const oldUndo = vi.fn();
+    const newUndo = vi.fn();
+
+    UndoManager.getInstance().register({ message: '古い', undo: oldUndo });
+    UndoManager.getInstance().register({ message: '新しい', undo: newUndo });
+
+    expect(UndoManager.getInstance().hasUndo()).toBe(true);
+    const toasts = document.querySelectorAll('.app-toast');
+    expect(toasts.length).toBe(1);
+    expect(toasts[0].textContent).toContain('新しい');
+  });
+
+  it('triggerUndo() で undo が実行される', async () => {
+    const undoFn = vi.fn();
+    UndoManager.getInstance().register({ message: 'メッセージ', undo: undoFn });
+
+    const handled = await UndoManager.getInstance().triggerUndo();
+    expect(handled).toBe(true);
+    expect(undoFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd+Z で undo が実行される', async () => {
+    const undoFn = vi.fn();
+    UndoManager.getInstance().initialize();
+    UndoManager.getInstance().register({ message: 'メッセージ', undo: undoFn });
+
+    const event = new dom.window.KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+    });
+    document.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(undoFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('入力欄にフォーカスがあるとき Cmd+Z は標準動作を優先する', async () => {
+    const undoFn = vi.fn();
+    UndoManager.getInstance().initialize();
+    UndoManager.getInstance().register({ message: 'メッセージ', undo: undoFn });
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    const event = new dom.window.KeyboardEvent('keydown', {
+      key: 'z',
+      metaKey: true,
+    });
+    document.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(undoFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- 汎用 `Toast` コンポーネントを追加し、削除・移動などの破壊的操作後に「元に戻す」ボタンを表示
- `UndoManager` を追加し、`Cmd/Ctrl+Z` でも直前操作を取り消せるように
- `BookmarkDeleter`: 削除前に位置情報 (`parentId` / `index`) を保持し、Undo で同じ場所に復元。`window.location.reload()` を廃止し、`bookmarks-changed` イベントベースに統一
- `BookmarkDragAndDrop`: 移動前の `parentId` / `index` を保持し、Undo で元の位置に戻す

## 設計判断
- **深さ1の置換戦略**: 新しい Undo が来たら古いものを破棄。Chrome API の制約で復元時に id が変わるため、複数履歴を持つと古い操作の Undo が壊れやすく UX も分かりにくくなる
- **Cmd/Ctrl+Z は入力欄では標準動作を優先**: `<input>` / `<textarea>` / `<select>` / contentEditable にフォーカスがある場合は Undo を発火しない

## Test plan
- [x] `npm test` (129 tests passed — 既存 + Toast 8 + UndoManager 6 + 拡張済み削除テスト)
- [x] `npm run lint` (変更ファイルのみ)
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機でブックマーク削除→Toast→「元に戻す」で復元
- [x] 実機でブックマーク削除→Cmd/Ctrl+Z で復元
- [x] 実機でブックマークを DnD 移動→「元に戻す」で元のフォルダ・位置に戻る
- [x] 入力欄にフォーカス時の Cmd+Z が標準動作 (テキスト Undo) になる

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)