### PR TITLE
カレンダー検索欄の Cmd+Z 挙動を修正 (#62)

### DIFF
--- a/src/components/CalendarHistoryPanel/CalendarHistoryPanel.ts
+++ b/src/components/CalendarHistoryPanel/CalendarHistoryPanel.ts
@@ -87,11 +87,15 @@ export class CalendarHistoryPanel {
       });
 
     // 検索入力の監視
+    // selectedDate が無くても毎回 renderTimeline を呼ぶことで、入力ごとに DOM が更新され
+    // ブラウザの undo (Cmd+Z) が他の検索欄と同様に細かい単位で動くようにする
     this.searchInput?.addEventListener('input', (e) => {
       const target = e.target as HTMLInputElement;
       this.searchTerm = target.value;
       if (this.selectedDate) {
         this.renderTimeline(this.selectedDate);
+      } else {
+        this.renderEmptyTimeline();
       }
     });
 
@@ -278,6 +282,20 @@ export class CalendarHistoryPanel {
         }
       });
     }
+  }
+
+  /**
+   * 日付未選択時のプレースホルダー表示。
+   * 検索入力時にも毎回呼び出すことで DOM を更新し、ブラウザの undo 履歴を
+   * 細かい単位で記録させる目的も兼ねる。
+   */
+  private renderEmptyTimeline(): void {
+    const timelineElement = this.container.querySelector(
+      '.history-timeline'
+    ) as HTMLElement;
+    if (!timelineElement) return;
+    timelineElement.innerHTML =
+      '<div class="timeline-placeholder">日付を選択してください</div>';
   }
 
   private renderTimeline(date: Date): void {


### PR DESCRIPTION
## Summary
カレンダー履歴タブの検索入力欄で Cmd+Z (Ctrl+Z) が複数文字を一気に消す問題を修正。

## 原因
`CalendarHistoryPanel` の input ハンドラは `selectedDate` 選択時のみ `renderTimeline` を呼んでいた。日付未選択の状態で入力すると DOM が更新されず、ブラウザが連続入力を1つの undo 単位として扱うため、Cmd+Z で全部消える挙動になっていた。

## 修正
日付未選択時は `renderEmptyTimeline()` で空状態を再描画するように変更。ブラウザの undo 履歴が細かい単位で記録される。

## Test plan
- [x] `npm test` (143 tests passed)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: カレンダー検索欄で日付未選択時に文字入力 → Cmd+Z で1文字ずつ消えることを確認

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)