### PR TITLE
フォルダの新規作成機能 (#51)

### DIFF
--- a/src/components/BookmarkActions/FolderCreator.ts
+++ b/src/components/BookmarkActions/FolderCreator.ts
@@ -1,0 +1,176 @@
+import { escapeHtml } from '../../scripts/utils.js';
+import type { ChromeBookmarkNode } from '../../types/bookmark.js';
+import { UndoManager } from '../UndoManager/index.js';
+
+/**
+ * フォルダの新規作成機能。
+ * 親フォルダ選択 + 名前入力のダイアログを表示し、Chrome API でフォルダを作成する。
+ */
+export class FolderCreator {
+  /**
+   * フォルダ作成ダイアログを開く。
+   *
+   * @param defaultParentId 既定で選択する親フォルダのID
+   */
+  async openCreateDialog(defaultParentId?: string): Promise<void> {
+    try {
+      const folders = await this.getAllFolders();
+      this.showDialog(folders, defaultParentId);
+    } catch (error) {
+      console.error('❌ フォルダ作成ダイアログの表示に失敗:', error);
+    }
+  }
+
+  private async getAllFolders(): Promise<ChromeBookmarkNode[]> {
+    const tree = await chrome.bookmarks.getTree();
+    const folders: ChromeBookmarkNode[] = [];
+    const collect = (nodes: ChromeBookmarkNode[]) => {
+      for (const node of nodes) {
+        if (node.children && !node.url) {
+          folders.push(node);
+          collect(node.children);
+        }
+      }
+    };
+    collect(tree);
+    return folders;
+  }
+
+  private showDialog(
+    folders: ChromeBookmarkNode[],
+    defaultParentId?: string
+  ): void {
+    const existing = document.getElementById('folder-create-dialog');
+    existing?.remove();
+
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      this.createDialogHTML(folders, defaultParentId)
+    );
+
+    this.setupDialogEvents();
+    const nameInput = document.getElementById(
+      'folder-create-name'
+    ) as HTMLInputElement | null;
+    nameInput?.focus();
+  }
+
+  private createDialogHTML(
+    folders: ChromeBookmarkNode[],
+    defaultParentId?: string
+  ): string {
+    // ルートフォルダ（id=0 など）は表示用に明示的にラベルを付与する
+    const folderOptions = folders
+      .map((folder) => {
+        const selected = folder.id === defaultParentId ? 'selected' : '';
+        const label = folder.title || `(ルート: ${folder.id})`;
+        return `<option value="${escapeHtml(folder.id)}" ${selected}>${escapeHtml(label)}</option>`;
+      })
+      .join('');
+
+    return `
+      <div id="folder-create-dialog" class="edit-dialog-overlay">
+        <div class="edit-dialog">
+          <div class="edit-dialog-header">
+            <h3>新しいフォルダを作成</h3>
+            <button class="edit-dialog-close" type="button">×</button>
+          </div>
+          <div class="edit-dialog-content">
+            <div class="edit-form-group">
+              <label for="folder-create-name">フォルダ名:</label>
+              <input type="text" id="folder-create-name" placeholder="新しいフォルダ" />
+            </div>
+            <div class="edit-form-group">
+              <label for="folder-create-parent">親フォルダ:</label>
+              <select id="folder-create-parent">
+                ${folderOptions}
+              </select>
+            </div>
+          </div>
+          <div class="edit-dialog-actions">
+            <button type="button" class="edit-dialog-cancel">キャンセル</button>
+            <button type="button" class="folder-create-confirm">作成</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private setupDialogEvents(): void {
+    const dialog = document.getElementById('folder-create-dialog');
+    const closeBtn = dialog?.querySelector('.edit-dialog-close');
+    const cancelBtn = dialog?.querySelector('.edit-dialog-cancel');
+    const confirmBtn = dialog?.querySelector('.folder-create-confirm');
+    const nameInput = document.getElementById(
+      'folder-create-name'
+    ) as HTMLInputElement | null;
+
+    closeBtn?.addEventListener('click', () => this.closeDialog());
+    cancelBtn?.addEventListener('click', () => this.closeDialog());
+    confirmBtn?.addEventListener('click', () => {
+      void this.handleConfirm();
+    });
+
+    nameInput?.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        void this.handleConfirm();
+      }
+    });
+
+    const keydownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        this.closeDialog();
+        document.removeEventListener('keydown', keydownHandler);
+      }
+    };
+    document.addEventListener('keydown', keydownHandler);
+  }
+
+  private async handleConfirm(): Promise<void> {
+    const nameInput = document.getElementById(
+      'folder-create-name'
+    ) as HTMLInputElement | null;
+    const parentSelect = document.getElementById(
+      'folder-create-parent'
+    ) as HTMLSelectElement | null;
+    if (!nameInput || !parentSelect) return;
+
+    const title = nameInput.value.trim();
+    const parentId = parentSelect.value;
+
+    if (!title) {
+      nameInput.focus();
+      return;
+    }
+
+    try {
+      const created = await chrome.bookmarks.create({ parentId, title });
+
+      this.closeDialog();
+      this.dispatchBookmarksChanged('folder-create');
+
+      // Undo: 作成したフォルダを削除
+      if (created.id) {
+        UndoManager.getInstance().register({
+          message: `フォルダ「${title}」を作成しました`,
+          undo: async () => {
+            await chrome.bookmarks.removeTree(created.id);
+            this.dispatchBookmarksChanged('undo-folder-create');
+          },
+        });
+      }
+    } catch (error) {
+      console.error('❌ フォルダの作成に失敗しました:', error);
+    }
+  }
+
+  private dispatchBookmarksChanged(action: string): void {
+    const event = new CustomEvent('bookmarks-changed', { detail: { action } });
+    document.dispatchEvent(event);
+  }
+
+  private closeDialog(): void {
+    document.getElementById('folder-create-dialog')?.remove();
+  }
+}

--- a/src/components/BookmarkActions/FolderCreator.ts
+++ b/src/components/BookmarkActions/FolderCreator.ts
@@ -89,7 +89,7 @@ export class FolderCreator {
           </div>
           <div class="edit-dialog-actions">
             <button type="button" class="edit-dialog-cancel">キャンセル</button>
-            <button type="button" class="folder-create-confirm">作成</button>
+            <button type="button" class="edit-dialog-save folder-create-confirm">作成</button>
           </div>
         </div>
       </div>

--- a/src/components/BookmarkFolder/BookmarkFolderEvents.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderEvents.ts
@@ -1,5 +1,6 @@
 import { findFolderById } from '../../scripts/utils.js';
 import type { BookmarkFolder, BookmarkItem } from '../../types/bookmark.js';
+import { FolderCreator } from '../BookmarkActions/FolderCreator.js';
 import { BookmarkActions } from '../BookmarkActions/index.js';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu/index.js';
 
@@ -12,10 +13,12 @@ export class BookmarkFolderEvents {
   private contextMenuHandler: ((e: Event) => void) | null = null;
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
   private contextMenu: ContextMenu;
+  private folderCreator: FolderCreator;
 
   constructor() {
     this.bookmarkActions = new BookmarkActions();
     this.contextMenu = new ContextMenu();
+    this.folderCreator = new FolderCreator();
   }
 
   /**
@@ -278,9 +281,8 @@ export class BookmarkFolderEvents {
         label: '新規サブフォルダ',
         icon: '➕',
         separatorBefore: true,
-        disabled: true,
         onSelect: () => {
-          console.warn('新規サブフォルダ機能は別 issue (#51) で実装予定です');
+          void this.folderCreator.openCreateDialog(folder.id);
         },
       },
       {

--- a/test/bookmark-context-menu.test.ts
+++ b/test/bookmark-context-menu.test.ts
@@ -155,7 +155,7 @@ describe('右クリックコンテキストメニュー統合', () => {
     expect(labels).toContain('フォルダを削除');
   });
 
-  it('フォルダの未実装メニュー項目は disabled になっている', () => {
+  it('フォルダの未実装メニュー項目（リネーム・削除）は disabled、新規サブフォルダは有効', () => {
     const folderHeader = container.querySelector(
       '.folder-header'
     ) as HTMLElement;
@@ -176,7 +176,7 @@ describe('右クリックコンテキストメニュー統合', () => {
 
     expect(rename?.disabled).toBe(true);
     expect(remove?.disabled).toBe(true);
-    expect(newSub?.disabled).toBe(true);
+    expect(newSub?.disabled).toBe(false);
   });
 
   it('「中のブックマークを全て新しいタブで開く」を選択すると全URLが開かれる', () => {

--- a/test/folder-create.test.ts
+++ b/test/folder-create.test.ts
@@ -1,0 +1,200 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FolderCreator } from '../src/components/BookmarkActions/FolderCreator';
+import { Toast } from '../src/components/Toast/index';
+import { UndoManager } from '../src/components/UndoManager/index';
+
+describe('FolderCreator', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+      url: 'chrome-extension://test/newtab.html',
+    });
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
+
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: {
+        getTree: ReturnType<typeof vi.fn>;
+        create: ReturnType<typeof vi.fn>;
+        removeTree: ReturnType<typeof vi.fn>;
+      };
+    };
+    mockChrome.bookmarks.getTree = vi.fn().mockResolvedValue([
+      {
+        id: '0',
+        title: '',
+        children: [
+          {
+            id: '1',
+            title: 'ブックマークバー',
+            children: [{ id: '11', title: 'サブ', children: [] }],
+          },
+          { id: '2', title: 'その他のブックマーク', children: [] },
+        ],
+      },
+    ]);
+    mockChrome.bookmarks.create = vi
+      .fn()
+      .mockResolvedValue({ id: 'new-folder', title: '新規' });
+    mockChrome.bookmarks.removeTree = vi.fn().mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('openCreateDialog でダイアログが表示される', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('1');
+
+    const dialog = document.getElementById('folder-create-dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent).toContain('新しいフォルダを作成');
+  });
+
+  it('親フォルダの選択肢にすべてのフォルダが列挙される', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('1');
+
+    const select = document.getElementById(
+      'folder-create-parent'
+    ) as HTMLSelectElement;
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toContain('1');
+    expect(options).toContain('2');
+    expect(options).toContain('11');
+  });
+
+  it('defaultParentId で指定したフォルダが既定で選択される', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('11');
+
+    const select = document.getElementById(
+      'folder-create-parent'
+    ) as HTMLSelectElement;
+    expect(select.value).toBe('11');
+  });
+
+  it('作成ボタンで chrome.bookmarks.create が呼ばれ bookmarks-changed が発火される', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('1');
+
+    const nameInput = document.getElementById(
+      'folder-create-name'
+    ) as HTMLInputElement;
+    nameInput.value = '新規フォルダ';
+
+    const changedSpy = vi.fn();
+    document.addEventListener('bookmarks-changed', changedSpy);
+
+    const confirmBtn = document.querySelector(
+      '.folder-create-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.create).toHaveBeenCalledWith({
+      parentId: '1',
+      title: '新規フォルダ',
+    });
+    expect(changedSpy).toHaveBeenCalled();
+    expect(document.getElementById('folder-create-dialog')).toBeNull();
+
+    document.removeEventListener('bookmarks-changed', changedSpy);
+  });
+
+  it('フォルダ名が空のときは作成されない', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('1');
+
+    const confirmBtn = document.querySelector(
+      '.folder-create-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.create).not.toHaveBeenCalled();
+    expect(document.getElementById('folder-create-dialog')).not.toBeNull();
+  });
+
+  it('作成後に Undo Toast が表示され、Undo で removeTree が呼ばれる', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('1');
+
+    const nameInput = document.getElementById(
+      'folder-create-name'
+    ) as HTMLInputElement;
+    nameInput.value = '新規フォルダ';
+
+    const confirmBtn = document.querySelector(
+      '.folder-create-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toContain('新規フォルダ');
+
+    (toast?.querySelector('.app-toast-action') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.removeTree).toHaveBeenCalledWith('new-folder');
+  });
+
+  it('Enter キーで作成が実行される', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('1');
+
+    const nameInput = document.getElementById(
+      'folder-create-name'
+    ) as HTMLInputElement;
+    nameInput.value = 'Enter作成';
+
+    const event = new dom.window.KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+    });
+    nameInput.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.create).toHaveBeenCalledWith({
+      parentId: '1',
+      title: 'Enter作成',
+    });
+  });
+
+  it('ESC キーでダイアログが閉じる', async () => {
+    const creator = new FolderCreator();
+    await creator.openCreateDialog('1');
+
+    expect(document.getElementById('folder-create-dialog')).not.toBeNull();
+
+    const event = new dom.window.KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+
+    expect(document.getElementById('folder-create-dialog')).toBeNull();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -8,6 +8,10 @@ const mockChrome = {
     get: vi.fn(),
     create: vi.fn(),
     remove: vi.fn(),
+    removeTree: vi.fn(),
+    move: vi.fn(),
+    search: vi.fn(),
+    update: vi.fn(),
   },
   tabs: {
     create: vi.fn(),


### PR DESCRIPTION
## Summary
- `FolderCreator` コンポーネントを追加し、拡張内からフォルダを作成可能に
- フォルダ右クリックメニューの「新規サブフォルダ」（PR #59 で disabled だった項目）を有効化
- 親フォルダ選択ダイアログ: 既定値は右クリックされたフォルダ、ルートを含む全フォルダから選択可能
- 作成後は `bookmarks-changed` イベントで UI を即時更新（リロード不要）
- Undo 対応: `chrome.bookmarks.removeTree` で作成したフォルダを削除して取り消し
- Enter で作成 / ESC でキャンセル

## Test plan
- [x] `npm test` (151 tests passed — 既存 + folder-create 8件)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: フォルダ右クリック→「新規サブフォルダ」でダイアログ表示
- [x] 実機: 作成後、リロードなしでサブフォルダが現れる
- [x] 実機: Toast の「元に戻す」/ Cmd+Z で作成が取り消される
- [x] 実機: 親フォルダを別のフォルダに変更して作成できる

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)