### PR TITLE
フォルダのリネーム機能 (#52)

### DIFF
--- a/src/components/BookmarkActions/FolderRenamer.ts
+++ b/src/components/BookmarkActions/FolderRenamer.ts
@@ -1,0 +1,173 @@
+import { escapeHtml } from '../../scripts/utils.js';
+import type { ChromeBookmarkNode } from '../../types/bookmark.js';
+import { UndoManager } from '../UndoManager/index.js';
+
+/**
+ * フォルダのリネーム機能。
+ * 名前入力ダイアログを表示し、Chrome API でフォルダ名を更新する。
+ */
+export class FolderRenamer {
+  /**
+   * リネームダイアログを開く。
+   */
+  async openRenameDialog(folderId: string): Promise<void> {
+    try {
+      const [target] = await chrome.bookmarks.get(folderId);
+      if (!target) {
+        console.error('❌ リネーム対象のフォルダが見つかりません:', folderId);
+        return;
+      }
+      // 親フォルダの兄弟を取得して同名チェックに使う
+      const siblings = target.parentId
+        ? await chrome.bookmarks.getChildren(target.parentId)
+        : [];
+      this.showDialog(target, siblings);
+    } catch (error) {
+      console.error('❌ リネームダイアログの表示に失敗:', error);
+    }
+  }
+
+  private showDialog(
+    target: ChromeBookmarkNode,
+    siblings: ChromeBookmarkNode[]
+  ): void {
+    document.getElementById('folder-rename-dialog')?.remove();
+    document.body.insertAdjacentHTML(
+      'beforeend',
+      this.createDialogHTML(target)
+    );
+    this.setupDialogEvents(target, siblings);
+
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement | null;
+    input?.focus();
+    input?.select();
+  }
+
+  private createDialogHTML(target: ChromeBookmarkNode): string {
+    return `
+      <div id="folder-rename-dialog" class="edit-dialog-overlay">
+        <div class="edit-dialog">
+          <div class="edit-dialog-header">
+            <h3>フォルダ名を変更</h3>
+            <button class="edit-dialog-close" type="button">×</button>
+          </div>
+          <div class="edit-dialog-content">
+            <div class="edit-form-group">
+              <label for="folder-rename-name">新しいフォルダ名:</label>
+              <input type="text" id="folder-rename-name" value="${escapeHtml(target.title)}" />
+            </div>
+            <div class="folder-rename-error" style="display:none; color: var(--danger); margin-top: 8px;"></div>
+          </div>
+          <div class="edit-dialog-actions">
+            <button type="button" class="edit-dialog-cancel">キャンセル</button>
+            <button type="button" class="edit-dialog-save folder-rename-confirm">保存</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private setupDialogEvents(
+    target: ChromeBookmarkNode,
+    siblings: ChromeBookmarkNode[]
+  ): void {
+    const dialog = document.getElementById('folder-rename-dialog');
+    const closeBtn = dialog?.querySelector('.edit-dialog-close');
+    const cancelBtn = dialog?.querySelector('.edit-dialog-cancel');
+    const confirmBtn = dialog?.querySelector('.folder-rename-confirm');
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement | null;
+
+    closeBtn?.addEventListener('click', () => this.closeDialog());
+    cancelBtn?.addEventListener('click', () => this.closeDialog());
+    confirmBtn?.addEventListener('click', () => {
+      void this.handleConfirm(target, siblings);
+    });
+
+    input?.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        void this.handleConfirm(target, siblings);
+      }
+    });
+
+    const keydownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        this.closeDialog();
+        document.removeEventListener('keydown', keydownHandler);
+      }
+    };
+    document.addEventListener('keydown', keydownHandler);
+  }
+
+  private async handleConfirm(
+    target: ChromeBookmarkNode,
+    siblings: ChromeBookmarkNode[]
+  ): Promise<void> {
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement | null;
+    const errorEl = document.querySelector(
+      '.folder-rename-error'
+    ) as HTMLElement | null;
+    if (!input) return;
+
+    const newTitle = input.value.trim();
+
+    if (!newTitle) {
+      this.showError(errorEl, 'フォルダ名を入力してください。');
+      return;
+    }
+    if (newTitle === target.title) {
+      this.closeDialog();
+      return;
+    }
+    // 同階層の他フォルダと同名（自分自身は除く）
+    const duplicate = siblings.some(
+      (s) =>
+        s.id !== target.id &&
+        !s.url && // フォルダのみ対象
+        s.title === newTitle
+    );
+    if (duplicate) {
+      this.showError(errorEl, '同じ名前のフォルダが既に存在します。');
+      return;
+    }
+
+    const oldTitle = target.title;
+    try {
+      await chrome.bookmarks.update(target.id, { title: newTitle });
+      this.closeDialog();
+      this.dispatchBookmarksChanged('folder-rename');
+
+      UndoManager.getInstance().register({
+        message: `フォルダ名を「${newTitle}」に変更しました`,
+        undo: async () => {
+          await chrome.bookmarks.update(target.id, { title: oldTitle });
+          this.dispatchBookmarksChanged('undo-folder-rename');
+        },
+      });
+    } catch (error) {
+      console.error('❌ フォルダ名の変更に失敗しました:', error);
+      this.showError(errorEl, 'フォルダ名の変更に失敗しました。');
+    }
+  }
+
+  private showError(el: HTMLElement | null, message: string): void {
+    if (!el) return;
+    el.textContent = message;
+    el.style.display = 'block';
+  }
+
+  private dispatchBookmarksChanged(action: string): void {
+    const event = new CustomEvent('bookmarks-changed', { detail: { action } });
+    document.dispatchEvent(event);
+  }
+
+  private closeDialog(): void {
+    document.getElementById('folder-rename-dialog')?.remove();
+  }
+}

--- a/src/components/BookmarkFolder/BookmarkFolderEvents.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderEvents.ts
@@ -259,6 +259,10 @@ export class BookmarkFolderEvents {
     const hasBookmarks = allUrls.length > 0;
     const isExpandable =
       folder.subfolders.length > 0 || folder.bookmarks.length > 0;
+    // ブックマークバー・その他のブックマーク等の最上位パーマネントフォルダは
+    // Chrome の制約でリネーム不可。allBookmarks 配列のトップレベルに含まれる
+    // フォルダがそれに該当する
+    const isPermanentRoot = allBookmarks.some((f) => f.id === folder.id);
 
     const items: ContextMenuItem[] = [
       {
@@ -291,6 +295,7 @@ export class BookmarkFolderEvents {
       {
         label: 'フォルダ名を変更',
         icon: '✏️',
+        disabled: isPermanentRoot,
         onSelect: () => {
           void this.folderRenamer.openRenameDialog(folder.id);
         },

--- a/src/components/BookmarkFolder/BookmarkFolderEvents.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderEvents.ts
@@ -1,6 +1,7 @@
 import { findFolderById } from '../../scripts/utils.js';
 import type { BookmarkFolder, BookmarkItem } from '../../types/bookmark.js';
 import { FolderCreator } from '../BookmarkActions/FolderCreator.js';
+import { FolderRenamer } from '../BookmarkActions/FolderRenamer.js';
 import { BookmarkActions } from '../BookmarkActions/index.js';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu/index.js';
 
@@ -14,11 +15,13 @@ export class BookmarkFolderEvents {
   private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
   private contextMenu: ContextMenu;
   private folderCreator: FolderCreator;
+  private folderRenamer: FolderRenamer;
 
   constructor() {
     this.bookmarkActions = new BookmarkActions();
     this.contextMenu = new ContextMenu();
     this.folderCreator = new FolderCreator();
+    this.folderRenamer = new FolderRenamer();
   }
 
   /**
@@ -288,9 +291,8 @@ export class BookmarkFolderEvents {
       {
         label: 'フォルダ名を変更',
         icon: '✏️',
-        disabled: true,
         onSelect: () => {
-          console.warn('フォルダリネーム機能は別 issue (#52) で実装予定です');
+          void this.folderRenamer.openRenameDialog(folder.id);
         },
       },
       {

--- a/src/components/BookmarkFolder/BookmarkFolderEvents.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderEvents.ts
@@ -5,6 +5,10 @@ import { FolderRenamer } from '../BookmarkActions/FolderRenamer.js';
 import { BookmarkActions } from '../BookmarkActions/index.js';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu/index.js';
 
+// Chrome のパーマネントフォルダの ID
+// 1: ブックマークバー / 2: その他のブックマーク / 3: モバイルのブックマーク
+const PERMANENT_ROOT_IDS = new Set(['1', '2', '3']);
+
 /**
  * ブックマークフォルダーのイベント処理を担当するクラス
  */
@@ -259,10 +263,11 @@ export class BookmarkFolderEvents {
     const hasBookmarks = allUrls.length > 0;
     const isExpandable =
       folder.subfolders.length > 0 || folder.bookmarks.length > 0;
-    // ブックマークバー・その他のブックマーク等の最上位パーマネントフォルダは
-    // Chrome の制約でリネーム不可。allBookmarks 配列のトップレベルに含まれる
-    // フォルダがそれに該当する
-    const isPermanentRoot = allBookmarks.some((f) => f.id === folder.id);
+    // ブックマークバー (id=1)・その他のブックマーク (id=2)・モバイルのブックマーク
+    // (id=3) は Chrome のパーマネントフォルダで update / removeTree が必ず失敗する。
+    // ブックマークバー直下のユーザーフォルダはアプリ側で平坦化されて allBookmarks の
+    // トップレベルに並ぶが、それらはリネーム可能なので ID で厳密に判定する。
+    const isPermanentRoot = PERMANENT_ROOT_IDS.has(folder.id);
 
     const items: ContextMenuItem[] = [
       {

--- a/test/bookmark-context-menu.test.ts
+++ b/test/bookmark-context-menu.test.ts
@@ -155,7 +155,7 @@ describe('右クリックコンテキストメニュー統合', () => {
     expect(labels).toContain('フォルダを削除');
   });
 
-  it('フォルダ削除のみ disabled、新規サブフォルダ・リネームは有効', () => {
+  it('最上位フォルダ（ブックマークバー相当）はリネーム disabled、フォルダ削除も disabled、新規サブフォルダは有効', () => {
     const folderHeader = container.querySelector(
       '.folder-header'
     ) as HTMLElement;
@@ -174,9 +174,48 @@ describe('右クリックコンテキストメニュー統合', () => {
       b.textContent?.includes('新規サブフォルダ')
     );
 
-    expect(rename?.disabled).toBe(false);
+    // 最上位フォルダは Chrome の制約でリネーム不可
+    expect(rename?.disabled).toBe(true);
     expect(remove?.disabled).toBe(true);
     expect(newSub?.disabled).toBe(false);
+  });
+
+  it('サブフォルダではリネームが有効になる', () => {
+    const parentFolder: BookmarkFolder = {
+      id: 'parent-1',
+      title: '親',
+      expanded: true,
+      bookmarks: [],
+      subfolders: [
+        {
+          id: 'child-1',
+          title: '子',
+          expanded: true,
+          bookmarks: [],
+          subfolders: [],
+        },
+      ],
+    };
+    const subBookmarks = [parentFolder];
+    const renderer = new BookmarkFolderRenderer();
+    container.innerHTML = renderer.renderFolders(subBookmarks);
+    events.setupFolderClickHandler(container, subBookmarks);
+
+    const childFolderEl = container.querySelector(
+      '[data-folder-id="child-1"]'
+    ) as HTMLElement;
+    const childHeader = childFolderEl.querySelector(
+      '.folder-header'
+    ) as HTMLElement;
+    dispatchContextMenu(childHeader);
+
+    const buttons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.context-menu-item')
+    );
+    const rename = buttons.find((b) =>
+      b.textContent?.includes('フォルダ名を変更')
+    );
+    expect(rename?.disabled).toBe(false);
   });
 
   it('「中のブックマークを全て新しいタブで開く」を選択すると全URLが開かれる', () => {

--- a/test/bookmark-context-menu.test.ts
+++ b/test/bookmark-context-menu.test.ts
@@ -50,6 +50,7 @@ describe('右クリックコンテキストメニュー統合', () => {
     mockChrome.tabs.update = vi.fn();
 
     allBookmarks = [
+      // ユーザーフォルダ（ブックマークバー直下に作ったフォルダ相当）
       {
         id: 'folder-1',
         title: 'テストフォルダ',
@@ -66,6 +67,14 @@ describe('右クリックコンテキストメニュー統合', () => {
             favicon: null,
           },
         ],
+        subfolders: [],
+      },
+      // パーマネントフォルダ「その他のブックマーク」相当
+      {
+        id: '2',
+        title: 'その他のブックマーク',
+        expanded: false,
+        bookmarks: [],
         subfolders: [],
       },
     ];
@@ -155,9 +164,10 @@ describe('右クリックコンテキストメニュー統合', () => {
     expect(labels).toContain('フォルダを削除');
   });
 
-  it('最上位フォルダ（ブックマークバー相当）はリネーム disabled、フォルダ削除も disabled、新規サブフォルダは有効', () => {
+  it('ユーザーフォルダではリネームが有効', () => {
+    // folder-1 はユーザーフォルダ（ブックマークバー直下相当）
     const folderHeader = container.querySelector(
-      '.folder-header'
+      '[data-folder-id="folder-1"] .folder-header'
     ) as HTMLElement;
     dispatchContextMenu(folderHeader);
 
@@ -174,40 +184,17 @@ describe('右クリックコンテキストメニュー統合', () => {
       b.textContent?.includes('新規サブフォルダ')
     );
 
-    // 最上位フォルダは Chrome の制約でリネーム不可
-    expect(rename?.disabled).toBe(true);
+    expect(rename?.disabled).toBe(false);
     expect(remove?.disabled).toBe(true);
     expect(newSub?.disabled).toBe(false);
   });
 
-  it('サブフォルダではリネームが有効になる', () => {
-    const parentFolder: BookmarkFolder = {
-      id: 'parent-1',
-      title: '親',
-      expanded: true,
-      bookmarks: [],
-      subfolders: [
-        {
-          id: 'child-1',
-          title: '子',
-          expanded: true,
-          bookmarks: [],
-          subfolders: [],
-        },
-      ],
-    };
-    const subBookmarks = [parentFolder];
-    const renderer = new BookmarkFolderRenderer();
-    container.innerHTML = renderer.renderFolders(subBookmarks);
-    events.setupFolderClickHandler(container, subBookmarks);
-
-    const childFolderEl = container.querySelector(
-      '[data-folder-id="child-1"]'
+  it('Chrome のパーマネントフォルダ (id=2) ではリネームが disabled', () => {
+    // id=2 (その他のブックマーク) を右クリック
+    const folderHeader = container.querySelector(
+      '[data-folder-id="2"] .folder-header'
     ) as HTMLElement;
-    const childHeader = childFolderEl.querySelector(
-      '.folder-header'
-    ) as HTMLElement;
-    dispatchContextMenu(childHeader);
+    dispatchContextMenu(folderHeader);
 
     const buttons = Array.from(
       document.querySelectorAll<HTMLButtonElement>('.context-menu-item')
@@ -215,7 +202,7 @@ describe('右クリックコンテキストメニュー統合', () => {
     const rename = buttons.find((b) =>
       b.textContent?.includes('フォルダ名を変更')
     );
-    expect(rename?.disabled).toBe(false);
+    expect(rename?.disabled).toBe(true);
   });
 
   it('「中のブックマークを全て新しいタブで開く」を選択すると全URLが開かれる', () => {

--- a/test/bookmark-context-menu.test.ts
+++ b/test/bookmark-context-menu.test.ts
@@ -155,7 +155,7 @@ describe('右クリックコンテキストメニュー統合', () => {
     expect(labels).toContain('フォルダを削除');
   });
 
-  it('フォルダの未実装メニュー項目（リネーム・削除）は disabled、新規サブフォルダは有効', () => {
+  it('フォルダ削除のみ disabled、新規サブフォルダ・リネームは有効', () => {
     const folderHeader = container.querySelector(
       '.folder-header'
     ) as HTMLElement;
@@ -174,7 +174,7 @@ describe('右クリックコンテキストメニュー統合', () => {
       b.textContent?.includes('新規サブフォルダ')
     );
 
-    expect(rename?.disabled).toBe(true);
+    expect(rename?.disabled).toBe(false);
     expect(remove?.disabled).toBe(true);
     expect(newSub?.disabled).toBe(false);
   });

--- a/test/folder-rename.test.ts
+++ b/test/folder-rename.test.ts
@@ -1,0 +1,214 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FolderRenamer } from '../src/components/BookmarkActions/FolderRenamer';
+import { Toast } from '../src/components/Toast/index';
+import { UndoManager } from '../src/components/UndoManager/index';
+
+describe('FolderRenamer', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+      url: 'chrome-extension://test/newtab.html',
+    });
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
+
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: {
+        get: ReturnType<typeof vi.fn>;
+        getChildren: ReturnType<typeof vi.fn>;
+        update: ReturnType<typeof vi.fn>;
+      };
+    };
+    mockChrome.bookmarks.get = vi
+      .fn()
+      .mockResolvedValue([{ id: 'f1', parentId: 'p1', title: '元の名前' }]);
+    mockChrome.bookmarks.getChildren = vi.fn().mockResolvedValue([
+      { id: 'f1', parentId: 'p1', title: '元の名前' },
+      { id: 'f2', parentId: 'p1', title: '他のフォルダ' },
+    ]);
+    mockChrome.bookmarks.update = vi.fn().mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('openRenameDialog でダイアログが表示され、現在のフォルダ名が入力済みになる', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const dialog = document.getElementById('folder-rename-dialog');
+    expect(dialog).not.toBeNull();
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement;
+    expect(input.value).toBe('元の名前');
+  });
+
+  it('新しい名前で保存すると chrome.bookmarks.update が呼ばれる', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement;
+    input.value = '新しい名前';
+
+    const changedSpy = vi.fn();
+    document.addEventListener('bookmarks-changed', changedSpy);
+
+    const confirmBtn = document.querySelector(
+      '.folder-rename-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.update).toHaveBeenCalledWith('f1', {
+      title: '新しい名前',
+    });
+    expect(changedSpy).toHaveBeenCalled();
+    expect(document.getElementById('folder-rename-dialog')).toBeNull();
+
+    document.removeEventListener('bookmarks-changed', changedSpy);
+  });
+
+  it('空文字で保存しようとするとエラー表示され update は呼ばれない', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement;
+    input.value = '   ';
+
+    const confirmBtn = document.querySelector(
+      '.folder-rename-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.update).not.toHaveBeenCalled();
+    const errorEl = document.querySelector(
+      '.folder-rename-error'
+    ) as HTMLElement;
+    expect(errorEl?.style.display).toBe('block');
+    expect(errorEl?.textContent).toContain('フォルダ名を入力してください');
+  });
+
+  it('同階層に同名フォルダがある場合はエラー表示される', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement;
+    input.value = '他のフォルダ';
+
+    const confirmBtn = document.querySelector(
+      '.folder-rename-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.update).not.toHaveBeenCalled();
+    const errorEl = document.querySelector(
+      '.folder-rename-error'
+    ) as HTMLElement;
+    expect(errorEl?.style.display).toBe('block');
+    expect(errorEl?.textContent).toContain(
+      '同じ名前のフォルダが既に存在します'
+    );
+  });
+
+  it('変更がないとき (元の名前のまま) は update が呼ばれずダイアログだけ閉じる', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const confirmBtn = document.querySelector(
+      '.folder-rename-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.update).not.toHaveBeenCalled();
+    expect(document.getElementById('folder-rename-dialog')).toBeNull();
+  });
+
+  it('保存後に Undo Toast が表示され、Undo で元の名前に戻る', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement;
+    input.value = '新しい名前';
+
+    (
+      document.querySelector('.folder-rename-confirm') as HTMLButtonElement
+    ).click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+
+    (toast?.querySelector('.app-toast-action') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.update).toHaveBeenLastCalledWith('f1', {
+      title: '元の名前',
+    });
+  });
+
+  it('Enter キーで保存が実行される', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const input = document.getElementById(
+      'folder-rename-name'
+    ) as HTMLInputElement;
+    input.value = 'Enter保存';
+
+    const event = new dom.window.KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+    });
+    input.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(chrome.bookmarks.update).toHaveBeenCalledWith('f1', {
+      title: 'Enter保存',
+    });
+  });
+
+  it('ESC キーでダイアログが閉じる', async () => {
+    const renamer = new FolderRenamer();
+    await renamer.openRenameDialog('f1');
+
+    const event = new dom.window.KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+
+    expect(document.getElementById('folder-rename-dialog')).toBeNull();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -12,6 +12,7 @@ const mockChrome = {
     move: vi.fn(),
     search: vi.fn(),
     update: vi.fn(),
+    getChildren: vi.fn(),
   },
   tabs: {
     create: vi.fn(),


### PR DESCRIPTION
## Summary
- `FolderRenamer` を追加し、フォルダ右クリックメニューの「フォルダ名を変更」（PR #59 で disabled だった項目）を有効化
- ダイアログに現在のフォルダ名を初期表示、入力フォーカス時にテキストを全選択
- バリデーション: 空文字 / 同階層に同名フォルダがある場合はインラインエラー表示
- 保存後は `bookmarks-changed` で UI を即時更新
- Undo 対応: 元のフォルダ名に戻す

## Test plan
- [x] `npm test` (159 tests passed — 既存 + folder-rename 8件)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: フォルダ右クリック→「フォルダ名を変更」でリネーム
- [x] 実機: 同名チェックが動作することを確認
- [x] 実機: Undo (Toast / Cmd+Z) で元のフォルダ名に戻る

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)