### PR TITLE
フォルダの削除機能 (#53)

### DIFF
--- a/src/components/BookmarkActions/FolderDeleter.ts
+++ b/src/components/BookmarkActions/FolderDeleter.ts
@@ -1,0 +1,194 @@
+import { escapeHtml } from '../../scripts/utils.js';
+import type { ChromeBookmarkNode } from '../../types/bookmark.js';
+import { UndoManager } from '../UndoManager/index.js';
+
+/**
+ * フォルダの削除機能。
+ * サブツリー全体を保持してから removeTree し、Undo では再帰的に再作成する。
+ */
+export class FolderDeleter {
+  /**
+   * 削除確認ダイアログを開く。
+   */
+  async openDeleteDialog(folderId: string): Promise<void> {
+    try {
+      const [subtree] = await chrome.bookmarks.getSubTree(folderId);
+      if (!subtree) {
+        console.error('❌ 削除対象のフォルダが見つかりません:', folderId);
+        return;
+      }
+      const counts = this.countContents(subtree);
+      const confirmed = await this.showConfirmation(
+        subtree.title,
+        counts.bookmarks,
+        counts.folders
+      );
+      if (!confirmed) return;
+
+      // 削除前にサブツリーを保持
+      const snapshot = this.snapshot(subtree);
+      const parentId = subtree.parentId;
+      const originalIndex = subtree.index;
+
+      await chrome.bookmarks.removeTree(subtree.id);
+      this.dispatchBookmarksChanged('folder-delete');
+
+      // Undo: サブツリーを再帰的に再作成
+      if (parentId) {
+        UndoManager.getInstance().register({
+          message: `フォルダ「${subtree.title}」を削除しました`,
+          undo: async () => {
+            await this.restoreSubtree(snapshot, parentId, originalIndex);
+            this.dispatchBookmarksChanged('undo-folder-delete');
+          },
+        });
+      }
+    } catch (error) {
+      console.error('❌ フォルダの削除に失敗しました:', error);
+    }
+  }
+
+  /**
+   * フォルダ内のブックマーク数とサブフォルダ数を再帰的にカウントする。
+   */
+  private countContents(node: ChromeBookmarkNode): {
+    bookmarks: number;
+    folders: number;
+  } {
+    let bookmarks = 0;
+    let folders = 0;
+    const walk = (n: ChromeBookmarkNode) => {
+      if (!n.children) return;
+      for (const child of n.children) {
+        if (child.url) {
+          bookmarks++;
+        } else if (child.children) {
+          folders++;
+          walk(child);
+        }
+      }
+    };
+    walk(node);
+    return { bookmarks, folders };
+  }
+
+  /**
+   * サブツリーを Undo 用にスナップショット化する。
+   * （ID は復元時に変わるため除外）
+   */
+  private snapshot(node: ChromeBookmarkNode): SnapshotNode {
+    return {
+      title: node.title,
+      url: node.url,
+      children: node.children?.map((c) => this.snapshot(c)),
+    };
+  }
+
+  /**
+   * スナップショットから再帰的にツリーを再作成する。
+   */
+  private async restoreSubtree(
+    node: SnapshotNode,
+    parentId: string,
+    index?: number
+  ): Promise<void> {
+    const created = await chrome.bookmarks.create({
+      parentId,
+      index,
+      title: node.title,
+      url: node.url,
+    });
+    if (node.children && created.id) {
+      for (const child of node.children) {
+        await this.restoreSubtree(child, created.id);
+      }
+    }
+  }
+
+  private async showConfirmation(
+    title: string,
+    bookmarkCount: number,
+    folderCount: number
+  ): Promise<boolean> {
+    return new Promise((resolve) => {
+      document.getElementById('folder-delete-dialog')?.remove();
+      document.body.insertAdjacentHTML(
+        'beforeend',
+        this.createDialogHTML(title, bookmarkCount, folderCount)
+      );
+      this.setupDialogEvents(resolve);
+    });
+  }
+
+  private createDialogHTML(
+    title: string,
+    bookmarkCount: number,
+    folderCount: number
+  ): string {
+    const contentWarning =
+      bookmarkCount > 0 || folderCount > 0
+        ? `<p class="delete-warning">中の ${bookmarkCount}件のブックマーク${
+            folderCount > 0 ? ` と ${folderCount}件のサブフォルダ` : ''
+          } も削除されます。</p>`
+        : '';
+
+    return `
+      <div id="folder-delete-dialog" class="edit-dialog-overlay">
+        <div class="edit-dialog">
+          <div class="edit-dialog-header">
+            <h3>フォルダを削除</h3>
+            <button class="edit-dialog-close" type="button">×</button>
+          </div>
+          <div class="edit-dialog-content">
+            <div class="delete-confirmation-message">
+              <p>以下のフォルダを削除しますか？</p>
+              <div class="delete-bookmark-info">
+                <strong>${escapeHtml(title)}</strong>
+              </div>
+              ${contentWarning}
+            </div>
+          </div>
+          <div class="edit-dialog-actions">
+            <button type="button" class="edit-dialog-cancel">キャンセル</button>
+            <button type="button" class="delete-dialog-confirm folder-delete-confirm">削除</button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private setupDialogEvents(resolve: (value: boolean) => void): void {
+    const dialog = document.getElementById('folder-delete-dialog');
+    const closeBtn = dialog?.querySelector('.edit-dialog-close');
+    const cancelBtn = dialog?.querySelector('.edit-dialog-cancel');
+    const confirmBtn = dialog?.querySelector('.folder-delete-confirm');
+
+    const close = (confirmed: boolean) => {
+      dialog?.remove();
+      resolve(confirmed);
+    };
+
+    closeBtn?.addEventListener('click', () => close(false));
+    cancelBtn?.addEventListener('click', () => close(false));
+    confirmBtn?.addEventListener('click', () => close(true));
+
+    const keydownHandler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close(false);
+        document.removeEventListener('keydown', keydownHandler);
+      }
+    };
+    document.addEventListener('keydown', keydownHandler);
+  }
+
+  private dispatchBookmarksChanged(action: string): void {
+    const event = new CustomEvent('bookmarks-changed', { detail: { action } });
+    document.dispatchEvent(event);
+  }
+}
+
+interface SnapshotNode {
+  title: string;
+  url?: string;
+  children?: SnapshotNode[];
+}

--- a/src/components/BookmarkFolder/BookmarkFolderEvents.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderEvents.ts
@@ -1,6 +1,7 @@
 import { findFolderById } from '../../scripts/utils.js';
 import type { BookmarkFolder, BookmarkItem } from '../../types/bookmark.js';
 import { FolderCreator } from '../BookmarkActions/FolderCreator.js';
+import { FolderDeleter } from '../BookmarkActions/FolderDeleter.js';
 import { FolderRenamer } from '../BookmarkActions/FolderRenamer.js';
 import { BookmarkActions } from '../BookmarkActions/index.js';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu/index.js';
@@ -20,12 +21,14 @@ export class BookmarkFolderEvents {
   private contextMenu: ContextMenu;
   private folderCreator: FolderCreator;
   private folderRenamer: FolderRenamer;
+  private folderDeleter: FolderDeleter;
 
   constructor() {
     this.bookmarkActions = new BookmarkActions();
     this.contextMenu = new ContextMenu();
     this.folderCreator = new FolderCreator();
     this.folderRenamer = new FolderRenamer();
+    this.folderDeleter = new FolderDeleter();
   }
 
   /**
@@ -308,9 +311,9 @@ export class BookmarkFolderEvents {
       {
         label: 'フォルダを削除',
         icon: '🗑️',
-        disabled: true,
+        disabled: isPermanentRoot,
         onSelect: () => {
-          console.warn('フォルダ削除機能は別 issue (#53) で実装予定です');
+          void this.folderDeleter.openDeleteDialog(folder.id);
         },
       },
     ];

--- a/test/bookmark-context-menu.test.ts
+++ b/test/bookmark-context-menu.test.ts
@@ -164,8 +164,7 @@ describe('右クリックコンテキストメニュー統合', () => {
     expect(labels).toContain('フォルダを削除');
   });
 
-  it('ユーザーフォルダではリネームが有効', () => {
-    // folder-1 はユーザーフォルダ（ブックマークバー直下相当）
+  it('ユーザーフォルダではリネーム・削除・新規サブフォルダがすべて有効', () => {
     const folderHeader = container.querySelector(
       '[data-folder-id="folder-1"] .folder-header'
     ) as HTMLElement;
@@ -185,12 +184,11 @@ describe('右クリックコンテキストメニュー統合', () => {
     );
 
     expect(rename?.disabled).toBe(false);
-    expect(remove?.disabled).toBe(true);
+    expect(remove?.disabled).toBe(false);
     expect(newSub?.disabled).toBe(false);
   });
 
-  it('Chrome のパーマネントフォルダ (id=2) ではリネームが disabled', () => {
-    // id=2 (その他のブックマーク) を右クリック
+  it('Chrome のパーマネントフォルダ (id=2) ではリネーム・削除ともに disabled', () => {
     const folderHeader = container.querySelector(
       '[data-folder-id="2"] .folder-header'
     ) as HTMLElement;
@@ -202,7 +200,11 @@ describe('右クリックコンテキストメニュー統合', () => {
     const rename = buttons.find((b) =>
       b.textContent?.includes('フォルダ名を変更')
     );
+    const remove = buttons.find((b) =>
+      b.textContent?.includes('フォルダを削除')
+    );
     expect(rename?.disabled).toBe(true);
+    expect(remove?.disabled).toBe(true);
   });
 
   it('「中のブックマークを全て新しいタブで開く」を選択すると全URLが開かれる', () => {

--- a/test/folder-delete.test.ts
+++ b/test/folder-delete.test.ts
@@ -1,0 +1,170 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FolderDeleter } from '../src/components/BookmarkActions/FolderDeleter';
+import { Toast } from '../src/components/Toast/index';
+import { UndoManager } from '../src/components/UndoManager/index';
+
+describe('FolderDeleter', () => {
+  let dom: JSDOM;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+      url: 'chrome-extension://test/newtab.html',
+    });
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
+
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: {
+        getSubTree: ReturnType<typeof vi.fn>;
+        removeTree: ReturnType<typeof vi.fn>;
+        create: ReturnType<typeof vi.fn>;
+      };
+    };
+    // 削除対象のサブツリー: フォルダの中にブックマーク2件とサブフォルダ1件（中にブックマーク1件）
+    mockChrome.bookmarks.getSubTree = vi.fn().mockResolvedValue([
+      {
+        id: 'target',
+        parentId: 'parent',
+        index: 3,
+        title: '削除対象フォルダ',
+        children: [
+          { id: 'b1', title: 'B1', url: 'https://b1.example.com' },
+          { id: 'b2', title: 'B2', url: 'https://b2.example.com' },
+          {
+            id: 'sub',
+            title: 'サブ',
+            children: [
+              { id: 'b3', title: 'B3', url: 'https://b3.example.com' },
+            ],
+          },
+        ],
+      },
+    ]);
+    mockChrome.bookmarks.removeTree = vi.fn().mockResolvedValue(undefined);
+
+    // create は呼ばれるたびに連番のIDを返す
+    let createId = 1000;
+    mockChrome.bookmarks.create = vi.fn().mockImplementation(async () => ({
+      id: `restored-${createId++}`,
+    }));
+  });
+
+  afterEach(() => {
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('openDeleteDialog で確認ダイアログが表示される', async () => {
+    const deleter = new FolderDeleter();
+    void deleter.openDeleteDialog('target');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const dialog = document.getElementById('folder-delete-dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent).toContain('削除対象フォルダ');
+  });
+
+  it('中身がある場合は警告メッセージに件数が表示される', async () => {
+    const deleter = new FolderDeleter();
+    void deleter.openDeleteDialog('target');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const dialog = document.getElementById('folder-delete-dialog');
+    // ブックマーク3件 (b1, b2, b3) + サブフォルダ1件 (sub)
+    expect(dialog?.textContent).toContain('3件のブックマーク');
+    expect(dialog?.textContent).toContain('1件のサブフォルダ');
+  });
+
+  it('キャンセルすると removeTree が呼ばれない', async () => {
+    const deleter = new FolderDeleter();
+    const promise = deleter.openDeleteDialog('target');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const cancelBtn = document.querySelector(
+      '.edit-dialog-cancel'
+    ) as HTMLButtonElement;
+    cancelBtn.click();
+    await promise;
+
+    expect(chrome.bookmarks.removeTree).not.toHaveBeenCalled();
+    expect(document.getElementById('folder-delete-dialog')).toBeNull();
+  });
+
+  it('削除を確認すると removeTree が呼ばれ bookmarks-changed が発火する', async () => {
+    const deleter = new FolderDeleter();
+    const changedSpy = vi.fn();
+    document.addEventListener('bookmarks-changed', changedSpy);
+
+    const promise = deleter.openDeleteDialog('target');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const confirmBtn = document.querySelector(
+      '.folder-delete-confirm'
+    ) as HTMLButtonElement;
+    confirmBtn.click();
+    await promise;
+
+    expect(chrome.bookmarks.removeTree).toHaveBeenCalledWith('target');
+    expect(changedSpy).toHaveBeenCalled();
+    document.removeEventListener('bookmarks-changed', changedSpy);
+  });
+
+  it('Undo で削除されたサブツリーが再帰的に復元される', async () => {
+    const deleter = new FolderDeleter();
+
+    const promise = deleter.openDeleteDialog('target');
+    await new Promise((r) => setTimeout(r, 10));
+    (
+      document.querySelector('.folder-delete-confirm') as HTMLButtonElement
+    ).click();
+    await promise;
+
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+
+    (toast?.querySelector('.app-toast-action') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 50));
+
+    // ルートフォルダ + サブフォルダ + ブックマーク3件 = 5回 create が呼ばれる
+    expect(chrome.bookmarks.create).toHaveBeenCalledTimes(5);
+    // 最初のcreateは元のparentId/index/titleで呼ばれる
+    expect(chrome.bookmarks.create).toHaveBeenNthCalledWith(1, {
+      parentId: 'parent',
+      index: 3,
+      title: '削除対象フォルダ',
+      url: undefined,
+    });
+  });
+
+  it('ESC でダイアログが閉じる', async () => {
+    const deleter = new FolderDeleter();
+    void deleter.openDeleteDialog('target');
+    await new Promise((r) => setTimeout(r, 10));
+
+    const event = new dom.window.KeyboardEvent('keydown', { key: 'Escape' });
+    document.dispatchEvent(event);
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(document.getElementById('folder-delete-dialog')).toBeNull();
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -13,6 +13,7 @@ const mockChrome = {
     search: vi.fn(),
     update: vi.fn(),
     getChildren: vi.fn(),
+    getSubTree: vi.fn(),
   },
   tabs: {
     create: vi.fn(),


### PR DESCRIPTION
## Summary
- `FolderDeleter` を追加し、フォルダ右クリックメニューの「フォルダを削除」（PR #59 で disabled だった項目）を有効化
- 確認ダイアログ: フォルダ名 + 中のブックマーク数 + サブフォルダ数を表示
- `chrome.bookmarks.removeTree` で再帰削除
- Undo 対応: 削除前にサブツリー全体をスナップショット化し、再帰的に `chrome.bookmarks.create` で復元（ID は再採番されるが構造とタイトル・URL は完全に戻る）
- パーマネントフォルダ (id=1/2/3) は削除も disabled

## Phase 2 完了
- #51 フォルダ新規作成 ✅
- #52 フォルダリネーム ✅
- #53 フォルダ削除 ✅（このPR）

## Test plan
- [x] `npm test` (166 tests passed — 既存 + folder-delete 6件)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: フォルダ右クリック→「フォルダを削除」で件数付き警告
- [x] 実機: 削除後、Undo で構造・ブックマークが完全に戻る
- [x] 実機: ブックマークバー等の削除メニューが disabled になっている

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)