### PR TITLE
ブックマークの複数選択・一括操作 (#47)

### DIFF
--- a/src/components/BookmarkFolder/BookmarkFolderEvents.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderEvents.ts
@@ -4,6 +4,7 @@ import { FolderCreator } from '../BookmarkActions/FolderCreator.js';
 import { FolderDeleter } from '../BookmarkActions/FolderDeleter.js';
 import { FolderRenamer } from '../BookmarkActions/FolderRenamer.js';
 import { BookmarkActions } from '../BookmarkActions/index.js';
+import { BookmarkSelection } from '../BookmarkSelection/index.js';
 import { ContextMenu, type ContextMenuItem } from '../ContextMenu/index.js';
 
 // Chrome のパーマネントフォルダの ID
@@ -24,13 +25,22 @@ export class BookmarkFolderEvents {
   private folderCreator: FolderCreator;
   private folderRenamer: FolderRenamer;
   private folderDeleter: FolderDeleter;
+  private selection: BookmarkSelection;
 
-  constructor() {
+  constructor(selection?: BookmarkSelection) {
     this.bookmarkActions = new BookmarkActions();
     this.contextMenu = new ContextMenu();
     this.folderCreator = new FolderCreator();
     this.folderRenamer = new FolderRenamer();
     this.folderDeleter = new FolderDeleter();
+    this.selection = selection ?? new BookmarkSelection();
+  }
+
+  /**
+   * 現在の選択管理オブジェクトを返す。
+   */
+  getSelection(): BookmarkSelection {
+    return this.selection;
   }
 
   /**
@@ -44,6 +54,9 @@ export class BookmarkFolderEvents {
     if (this.clickHandler) {
       container.removeEventListener('click', this.clickHandler);
     }
+
+    // 複数選択モジュールに最新のコンテナを通知
+    this.selection.refresh(container);
 
     // 新しいイベントリスナーを作成して保存
     this.clickHandler = (e: Event) => {
@@ -440,19 +453,42 @@ export class BookmarkFolderEvents {
   /**
    * ブックマークリンククリックの処理
    *
-   * - 通常クリック: 新しいタブ（アクティブ）で開く
-   * - Cmd/Ctrl + クリック: 新しいタブ（バックグラウンド）で開く
+   * - Shift+クリック: 複数選択 (範囲選択)。selection.handleClick が消費する
+   * - 既に選択中で修飾キーなしクリック: 選択解除を優先 (selection.handleClick が消費)
+   * - Cmd/Ctrl+クリック: 新しいタブをバックグラウンドで開く (#68)
+   * - 通常クリック: 現在のタブで開く
    */
   private handleBookmarkClick(e: Event, bookmarkLink: HTMLElement): void {
-    e.preventDefault();
+    const mouseEvent = e as MouseEvent;
     const url = bookmarkLink.getAttribute('data-url');
     if (!url) {
+      e.preventDefault();
       return;
     }
 
-    const mouseEvent = e as MouseEvent;
-    const openInBackground = Boolean(mouseEvent.metaKey || mouseEvent.ctrlKey);
+    const bookmarkItem = bookmarkLink.closest(
+      '.bookmark-item'
+    ) as HTMLElement | null;
+    const title =
+      bookmarkLink.querySelector('.bookmark-title')?.textContent?.trim() ?? '';
 
+    // 選択処理にイベントを渡す (Shift か、既に選択中の場合のみ消費される想定)
+    if (bookmarkItem) {
+      const consumed = this.selection.handleClick(
+        url,
+        title,
+        bookmarkItem,
+        mouseEvent
+      );
+      if (consumed) {
+        e.preventDefault();
+        e.stopPropagation();
+        return;
+      }
+    }
+
+    e.preventDefault();
+    const openInBackground = Boolean(mouseEvent.metaKey || mouseEvent.ctrlKey);
     chrome.tabs.create({ url, active: !openInBackground });
   }
 

--- a/src/components/BookmarkSelection/BookmarkSelection.ts
+++ b/src/components/BookmarkSelection/BookmarkSelection.ts
@@ -175,9 +175,11 @@ export class BookmarkSelection {
 
   /**
    * すべての選択を解除する (ESC など)
+   * 範囲選択のアンカー (lastClickedUrl) もリセットして、状態を完全に初期化する。
    */
   clear(): void {
     this.clearInternal();
+    this.lastClickedUrl = null;
     this.updateToolbar();
     // ESC を押した瞬間に :focus-visible が活性化し、選択時と似た outline
     // だけが残って崩れて見える問題を防ぐため、ブックマーク項目のフォーカスを外す

--- a/src/components/BookmarkSelection/BookmarkSelection.ts
+++ b/src/components/BookmarkSelection/BookmarkSelection.ts
@@ -1,0 +1,584 @@
+import { escapeHtml } from '../../scripts/utils.js';
+import type { ChromeBookmarkNode } from '../../types/bookmark.js';
+import { UndoManager } from '../UndoManager/index.js';
+
+/**
+ * 選択中のブックマークを表現する情報
+ */
+export interface SelectedBookmark {
+  url: string;
+  title: string;
+  /** ブックマーク要素のDOM参照 (DOM更新用) */
+  element: HTMLElement | null;
+}
+
+/**
+ * 一括移動・削除用にスナップショットを取った復元情報
+ */
+interface BookmarkRestoreInfo {
+  parentId: string | undefined;
+  index: number | undefined;
+  title: string;
+  url: string;
+}
+
+/**
+ * ブックマークの複数選択状態を管理し、一括操作 (削除/移動) を提供するクラス。
+ *
+ * - クリックモデル:
+ *   - 修飾キーなし: 単一選択へ切り替え (またはトグル)
+ *   - Shift+クリック: 直前にクリックしたアイテムからの範囲選択
+ *   - Cmd/Ctrl+クリック: 追加選択 (トグル)
+ * - 1件以上選択されているとフローティングツールバーを表示
+ * - ESC で選択解除
+ *
+ * 注意: 個々のブックマークは URL をキーとして管理する。
+ *       同じ URL が複数登録されている場合は同一として扱う (Chrome 上は通常一意)。
+ */
+export class BookmarkSelection {
+  private selected = new Map<string, SelectedBookmark>();
+  private lastClickedUrl: string | null = null;
+  private container: HTMLElement | null = null;
+  private toolbarElement: HTMLElement | null = null;
+  private orderedUrls: string[] = [];
+  private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
+
+  /**
+   * 選択モードを初期化する。
+   * container にはブックマーク表示領域を渡す (DOM 走査・更新用)。
+   */
+  initialize(container: HTMLElement): void {
+    this.container = container;
+    this.refreshOrderedUrls();
+    this.ensureKeydownHandler();
+  }
+
+  /**
+   * コンテナを再設定し、表示順を更新する。
+   * ブックマーク再描画後に呼ぶ。
+   */
+  refresh(container: HTMLElement): void {
+    this.container = container;
+    this.refreshOrderedUrls();
+    this.ensureKeydownHandler();
+    // 表示中の DOM 要素が変わるので、選択中アイテムにクラスを再適用する
+    this.reapplySelectionToDom();
+    this.updateToolbar();
+  }
+
+  /**
+   * クリック時の選択処理。
+   * @returns true ならクリック処理を消費した (通常のリンク遷移を抑制する)
+   */
+  handleClick(
+    url: string,
+    title: string,
+    element: HTMLElement,
+    e: MouseEvent
+  ): boolean {
+    if (e.shiftKey) {
+      this.selectRange(url, title, element);
+      this.lastClickedUrl = url;
+      return true;
+    }
+
+    // Cmd/Ctrl+クリックは新しいタブで開く動作 (#68) に譲るため、選択処理はしない。
+    // 非連続な複数選択は、コンテキストメニューや別途のトグルで対応する想定。
+    if (e.metaKey || e.ctrlKey) {
+      return false;
+    }
+
+    // 修飾キーなし: 既に複数選択がある場合は選択をリセット
+    // (単一選択中で同じアイテムなら解除、別アイテムなら通常のリンク遷移)
+    if (this.selected.size > 0) {
+      this.clear();
+      this.lastClickedUrl = null;
+      // 選択解除のみを消費。リンク遷移は次のクリックで行わせる。
+      return true;
+    }
+    this.lastClickedUrl = url;
+    return false;
+  }
+
+  /**
+   * 1件選択を追加/解除する (Cmd/Ctrl+クリック)
+   */
+  toggle(url: string, title: string, element: HTMLElement): void {
+    if (this.selected.has(url)) {
+      this.selected.delete(url);
+      element.classList.remove('selected');
+    } else {
+      this.selected.set(url, { url, title, element });
+      element.classList.add('selected');
+    }
+    this.updateToolbar();
+  }
+
+  /**
+   * 範囲選択 (Shift+クリック)
+   * 直前にクリックしたアイテムから現在のアイテムまでを選択状態にする。
+   */
+  selectRange(url: string, title: string, element: HTMLElement): void {
+    if (!this.container) {
+      this.toggle(url, title, element);
+      return;
+    }
+
+    // 表示順序を最新化
+    this.refreshOrderedUrls();
+
+    const anchor = this.lastClickedUrl;
+    if (!anchor || !this.orderedUrls.includes(anchor)) {
+      // アンカーがない場合は単一選択
+      this.selectOnly(url, title, element);
+      return;
+    }
+
+    const anchorIdx = this.orderedUrls.indexOf(anchor);
+    const targetIdx = this.orderedUrls.indexOf(url);
+    if (anchorIdx === -1 || targetIdx === -1) {
+      this.selectOnly(url, title, element);
+      return;
+    }
+
+    const [from, to] =
+      anchorIdx <= targetIdx ? [anchorIdx, targetIdx] : [targetIdx, anchorIdx];
+
+    // 範囲外を解除
+    this.clearInternal();
+
+    for (let i = from; i <= to; i++) {
+      const rangeUrl = this.orderedUrls[i];
+      const rangeEl = this.findItemByUrl(rangeUrl);
+      if (!rangeEl) continue;
+      const rangeTitle =
+        rangeEl.querySelector('.bookmark-title')?.textContent?.trim() ?? '';
+      this.selected.set(rangeUrl, {
+        url: rangeUrl,
+        title: rangeTitle,
+        element: rangeEl,
+      });
+      rangeEl.classList.add('selected');
+    }
+    this.updateToolbar();
+  }
+
+  /**
+   * 単一選択に切り替える
+   */
+  selectOnly(url: string, title: string, element: HTMLElement): void {
+    this.clearInternal();
+    this.selected.set(url, { url, title, element });
+    element.classList.add('selected');
+    this.updateToolbar();
+  }
+
+  /**
+   * すべての選択を解除する (ESC など)
+   */
+  clear(): void {
+    this.clearInternal();
+    this.updateToolbar();
+  }
+
+  private clearInternal(): void {
+    for (const item of this.selected.values()) {
+      item.element?.classList.remove('selected');
+    }
+    // 描画から外れた要素もクラス除去
+    if (this.container) {
+      const stale = this.container.querySelectorAll('.bookmark-item.selected');
+      for (const el of Array.from(stale)) {
+        el.classList.remove('selected');
+      }
+    }
+    this.selected.clear();
+  }
+
+  /**
+   * 選択件数
+   */
+  get count(): number {
+    return this.selected.size;
+  }
+
+  /**
+   * 選択中の URL 一覧 (テスト用)
+   */
+  getSelectedUrls(): string[] {
+    return Array.from(this.selected.keys());
+  }
+
+  /**
+   * 選択中アイテムを一括削除する。
+   */
+  async bulkDelete(): Promise<void> {
+    if (this.selected.size === 0) return;
+    const items = Array.from(this.selected.values());
+
+    const confirmed = await this.showConfirmDialog(
+      `選択中の ${items.length} 件のブックマークを削除します。よろしいですか？`,
+      '一括削除'
+    );
+    if (!confirmed) return;
+
+    const restoreInfos: BookmarkRestoreInfo[] = [];
+    try {
+      for (const item of items) {
+        const found = await chrome.bookmarks.search({ url: item.url });
+        if (found.length === 0) continue;
+        const target = found[0];
+        restoreInfos.push({
+          parentId: target.parentId,
+          index: target.index,
+          title: target.title,
+          url: target.url ?? item.url,
+        });
+        await chrome.bookmarks.remove(target.id);
+      }
+
+      this.clear();
+      this.dispatchBookmarksChanged('bulk-delete');
+
+      const count = restoreInfos.length;
+      UndoManager.getInstance().register({
+        message: `${count} 件のブックマークを削除しました`,
+        undo: async () => {
+          for (const info of restoreInfos) {
+            await chrome.bookmarks.create({
+              parentId: info.parentId,
+              index: info.index,
+              title: info.title,
+              url: info.url,
+            });
+          }
+          this.dispatchBookmarksChanged('undo-bulk-delete');
+        },
+      });
+    } catch (error) {
+      console.error('❌ 一括削除に失敗しました:', error);
+    }
+  }
+
+  /**
+   * 選択中アイテムを一括移動する。
+   */
+  async bulkMove(): Promise<void> {
+    if (this.selected.size === 0) return;
+    const items = Array.from(this.selected.values());
+
+    const folders = await this.getAllFolders();
+    const parentId = await this.showMoveDialog(folders, items.length);
+    if (!parentId) return;
+
+    const moveInfos: {
+      id: string;
+      previousParentId: string | undefined;
+      previousIndex: number | undefined;
+    }[] = [];
+    try {
+      for (const item of items) {
+        const found = await chrome.bookmarks.search({ url: item.url });
+        if (found.length === 0) continue;
+        const target = found[0];
+        moveInfos.push({
+          id: target.id,
+          previousParentId: target.parentId,
+          previousIndex: target.index,
+        });
+        await chrome.bookmarks.move(target.id, { parentId });
+      }
+
+      this.clear();
+      this.dispatchBookmarksChanged('bulk-move');
+
+      const count = moveInfos.length;
+      UndoManager.getInstance().register({
+        message: `${count} 件のブックマークを移動しました`,
+        undo: async () => {
+          for (const info of moveInfos) {
+            if (info.previousParentId === undefined) continue;
+            await chrome.bookmarks.move(info.id, {
+              parentId: info.previousParentId,
+              index: info.previousIndex,
+            });
+          }
+          this.dispatchBookmarksChanged('undo-bulk-move');
+        },
+      });
+    } catch (error) {
+      console.error('❌ 一括移動に失敗しました:', error);
+    }
+  }
+
+  // ---------------------------------------------------------------------
+  // 内部ヘルパー
+  // ---------------------------------------------------------------------
+
+  private refreshOrderedUrls(): void {
+    if (!this.container) {
+      this.orderedUrls = [];
+      return;
+    }
+    const links = this.container.querySelectorAll('.bookmark-link');
+    this.orderedUrls = Array.from(links)
+      .map((el) => el.getAttribute('data-url') ?? '')
+      .filter((url) => url.length > 0);
+  }
+
+  private findItemByUrl(url: string): HTMLElement | null {
+    if (!this.container) return null;
+    // CSS.escape が無い環境 (一部のテスト) でも動くようにフォールバック
+    const links = this.container.querySelectorAll('.bookmark-link');
+    for (const link of Array.from(links)) {
+      if (link.getAttribute('data-url') === url) {
+        return (link.closest('.bookmark-item') as HTMLElement | null) ?? null;
+      }
+    }
+    return null;
+  }
+
+  private reapplySelectionToDom(): void {
+    if (!this.container) return;
+    // 古いハイライトを除去
+    const stale = this.container.querySelectorAll('.bookmark-item.selected');
+    for (const el of Array.from(stale)) {
+      el.classList.remove('selected');
+    }
+    // 選択中のものに改めて付与
+    for (const item of this.selected.values()) {
+      const el = this.findItemByUrl(item.url);
+      if (el) {
+        el.classList.add('selected');
+        item.element = el;
+      }
+    }
+  }
+
+  private ensureKeydownHandler(): void {
+    if (this.keydownHandler) return;
+    this.keydownHandler = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (this.selected.size === 0) return;
+      // 入力欄にフォーカスがあるときはスキップ
+      const active = document.activeElement as HTMLElement | null;
+      if (active) {
+        const tag = active.tagName;
+        if (
+          tag === 'INPUT' ||
+          tag === 'TEXTAREA' ||
+          tag === 'SELECT' ||
+          active.isContentEditable
+        ) {
+          return;
+        }
+      }
+      // モーダル表示中は ESC をモーダル側に任せる
+      if (document.querySelector('.edit-dialog-overlay')) return;
+      e.preventDefault();
+      this.clear();
+    };
+    document.addEventListener('keydown', this.keydownHandler);
+  }
+
+  private updateToolbar(): void {
+    if (this.selected.size === 0) {
+      this.toolbarElement?.remove();
+      this.toolbarElement = null;
+      return;
+    }
+
+    if (!this.toolbarElement) {
+      this.toolbarElement = this.createToolbar();
+      document.body.appendChild(this.toolbarElement);
+    }
+
+    const countEl = this.toolbarElement.querySelector(
+      '.selection-toolbar-count'
+    );
+    if (countEl) {
+      countEl.textContent = `${this.selected.size} 件選択中`;
+    }
+  }
+
+  private createToolbar(): HTMLElement {
+    const toolbar = document.createElement('div');
+    toolbar.className = 'selection-toolbar';
+    toolbar.setAttribute('role', 'toolbar');
+    toolbar.setAttribute('aria-label', '選択中のブックマーク操作');
+    toolbar.innerHTML = `
+      <span class="selection-toolbar-count">0 件選択中</span>
+      <div class="selection-toolbar-actions">
+        <button type="button" class="selection-toolbar-btn selection-toolbar-move">移動</button>
+        <button type="button" class="selection-toolbar-btn selection-toolbar-delete">削除</button>
+        <button type="button" class="selection-toolbar-btn selection-toolbar-clear" aria-label="選択解除">×</button>
+      </div>
+    `;
+
+    toolbar
+      .querySelector('.selection-toolbar-move')
+      ?.addEventListener('click', () => {
+        void this.bulkMove();
+      });
+    toolbar
+      .querySelector('.selection-toolbar-delete')
+      ?.addEventListener('click', () => {
+        void this.bulkDelete();
+      });
+    toolbar
+      .querySelector('.selection-toolbar-clear')
+      ?.addEventListener('click', () => {
+        this.clear();
+      });
+
+    return toolbar;
+  }
+
+  private dispatchBookmarksChanged(action: string): void {
+    const event = new CustomEvent('bookmarks-changed', { detail: { action } });
+    document.dispatchEvent(event);
+  }
+
+  // ---------------------------------------------------------------------
+  // ダイアログ表示 (一括削除確認 / 移動先フォルダ選択)
+  // ---------------------------------------------------------------------
+
+  private async showConfirmDialog(
+    message: string,
+    title: string
+  ): Promise<boolean> {
+    return new Promise((resolve) => {
+      const existing = document.getElementById('bulk-confirm-dialog');
+      existing?.remove();
+
+      const html = `
+        <div id="bulk-confirm-dialog" class="edit-dialog-overlay">
+          <div class="edit-dialog">
+            <div class="edit-dialog-header">
+              <h3>${escapeHtml(title)}</h3>
+              <button class="edit-dialog-close" type="button">×</button>
+            </div>
+            <div class="edit-dialog-content">
+              <div class="delete-confirmation-message">
+                <p>${escapeHtml(message)}</p>
+                <p class="delete-warning">削除後 5 秒以内であれば「元に戻す」で復元できます。</p>
+              </div>
+            </div>
+            <div class="edit-dialog-actions">
+              <button type="button" class="edit-dialog-cancel">キャンセル</button>
+              <button type="button" class="delete-dialog-confirm">削除</button>
+            </div>
+          </div>
+        </div>
+      `;
+      document.body.insertAdjacentHTML('beforeend', html);
+
+      const dialog = document.getElementById('bulk-confirm-dialog');
+      const close = (result: boolean) => {
+        dialog?.remove();
+        resolve(result);
+      };
+      dialog
+        ?.querySelector('.edit-dialog-close')
+        ?.addEventListener('click', () => close(false));
+      dialog
+        ?.querySelector('.edit-dialog-cancel')
+        ?.addEventListener('click', () => close(false));
+      dialog
+        ?.querySelector('.delete-dialog-confirm')
+        ?.addEventListener('click', () => close(true));
+
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          document.removeEventListener('keydown', handleKey);
+          close(false);
+        }
+      };
+      document.addEventListener('keydown', handleKey);
+    });
+  }
+
+  private async showMoveDialog(
+    folders: ChromeBookmarkNode[],
+    count: number
+  ): Promise<string | null> {
+    return new Promise((resolve) => {
+      const existing = document.getElementById('bulk-move-dialog');
+      existing?.remove();
+
+      const folderOptions = folders
+        .map((folder) => {
+          const label = folder.title || `(ルート: ${folder.id})`;
+          return `<option value="${escapeHtml(folder.id)}">${escapeHtml(label)}</option>`;
+        })
+        .join('');
+
+      const html = `
+        <div id="bulk-move-dialog" class="edit-dialog-overlay">
+          <div class="edit-dialog">
+            <div class="edit-dialog-header">
+              <h3>${count} 件のブックマークを移動</h3>
+              <button class="edit-dialog-close" type="button">×</button>
+            </div>
+            <div class="edit-dialog-content">
+              <div class="edit-form-group">
+                <label for="bulk-move-parent">移動先フォルダ:</label>
+                <select id="bulk-move-parent">
+                  ${folderOptions}
+                </select>
+              </div>
+            </div>
+            <div class="edit-dialog-actions">
+              <button type="button" class="edit-dialog-cancel">キャンセル</button>
+              <button type="button" class="edit-dialog-save bulk-move-confirm">移動</button>
+            </div>
+          </div>
+        </div>
+      `;
+      document.body.insertAdjacentHTML('beforeend', html);
+
+      const dialog = document.getElementById('bulk-move-dialog');
+      const close = (result: string | null) => {
+        dialog?.remove();
+        resolve(result);
+      };
+      dialog
+        ?.querySelector('.edit-dialog-close')
+        ?.addEventListener('click', () => close(null));
+      dialog
+        ?.querySelector('.edit-dialog-cancel')
+        ?.addEventListener('click', () => close(null));
+      dialog
+        ?.querySelector('.bulk-move-confirm')
+        ?.addEventListener('click', () => {
+          const select = document.getElementById(
+            'bulk-move-parent'
+          ) as HTMLSelectElement | null;
+          close(select?.value ?? null);
+        });
+
+      const handleKey = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          document.removeEventListener('keydown', handleKey);
+          close(null);
+        }
+      };
+      document.addEventListener('keydown', handleKey);
+    });
+  }
+
+  private async getAllFolders(): Promise<ChromeBookmarkNode[]> {
+    const tree = await chrome.bookmarks.getTree();
+    const folders: ChromeBookmarkNode[] = [];
+    const collect = (nodes: ChromeBookmarkNode[]) => {
+      for (const node of nodes) {
+        if (node.children && !node.url) {
+          folders.push(node);
+          collect(node.children);
+        }
+      }
+    };
+    collect(tree as ChromeBookmarkNode[]);
+    return folders;
+  }
+}

--- a/src/components/BookmarkSelection/BookmarkSelection.ts
+++ b/src/components/BookmarkSelection/BookmarkSelection.ts
@@ -583,7 +583,11 @@ export class BookmarkSelection {
     const collect = (nodes: ChromeBookmarkNode[]) => {
       for (const node of nodes) {
         if (node.children && !node.url) {
-          folders.push(node);
+          // id='0' はツリーの仮想ルートで、ここへの move は Chrome API で
+          // 必ず失敗するため移動先候補から除外する
+          if (node.id !== '0') {
+            folders.push(node);
+          }
           collect(node.children);
         }
       }

--- a/src/components/BookmarkSelection/BookmarkSelection.ts
+++ b/src/components/BookmarkSelection/BookmarkSelection.ts
@@ -179,6 +179,16 @@ export class BookmarkSelection {
   clear(): void {
     this.clearInternal();
     this.updateToolbar();
+    // ESC を押した瞬間に :focus-visible が活性化し、選択時と似た outline
+    // だけが残って崩れて見える問題を防ぐため、ブックマーク項目のフォーカスを外す
+    this.blurFocusedBookmarkItem();
+  }
+
+  private blurFocusedBookmarkItem(): void {
+    const active = document.activeElement as HTMLElement | null;
+    if (active?.closest('.bookmark-item, .bookmark-link')) {
+      active.blur();
+    }
   }
 
   private clearInternal(): void {

--- a/src/components/BookmarkSelection/index.ts
+++ b/src/components/BookmarkSelection/index.ts
@@ -1,0 +1,2 @@
+export { BookmarkSelection } from './BookmarkSelection.js';
+export type { SelectedBookmark } from './BookmarkSelection.js';

--- a/src/styles.css
+++ b/src/styles.css
@@ -1653,12 +1653,15 @@ header h1 {
   cursor: pointer;
   font-size: 13px;
   transition: background-color var(--transition), color var(--transition),
-    border-color var(--transition);
+    border-color var(--transition), transform var(--transition),
+    box-shadow var(--transition), filter var(--transition);
 }
 
 .selection-toolbar-btn:hover {
   background: var(--surface-hover);
   border-color: var(--border-strong);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
 }
 
 .selection-toolbar-move {
@@ -1689,6 +1692,7 @@ header h1 {
 .selection-toolbar-delete:hover {
   background: rgba(220, 38, 38, 0.12);
   border-color: var(--danger);
+  box-shadow: 0 6px 18px rgba(220, 38, 38, 0.18);
 }
 
 .selection-toolbar-clear {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1668,7 +1668,12 @@ header h1 {
 }
 
 .selection-toolbar-move:hover {
-  filter: brightness(1.05);
+  /* .selection-toolbar-btn:hover の background/border を打ち消して
+     accent gradient を維持したまま明るくする */
+  background: var(--accent-gradient);
+  border-color: transparent;
+  filter: brightness(1.08);
+  box-shadow: var(--shadow-md);
 }
 
 .selection-toolbar-delete {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1665,15 +1665,20 @@ header h1 {
   background: var(--accent-gradient);
   color: var(--accent-contrast);
   border-color: transparent;
+  transition: background-color var(--transition), color var(--transition),
+    border-color var(--transition), transform var(--transition),
+    box-shadow var(--transition), filter var(--transition);
 }
 
 .selection-toolbar-move:hover {
-  /* .selection-toolbar-btn:hover の background/border を打ち消して
-     accent gradient を維持したまま明るくする */
+  /* .selection-toolbar-btn:hover の上書きを打ち消し、視覚変化を強める。
+     gradient を維持しつつ、明度・シャドウ・浮き上がりを加えて、
+     削除ボタンと同様にホバーが明確に分かるようにする。 */
   background: var(--accent-gradient);
   border-color: transparent;
-  filter: brightness(1.08);
-  box-shadow: var(--shadow-md);
+  filter: brightness(1.12) saturate(1.1);
+  box-shadow: 0 6px 18px var(--accent-soft-strong), var(--shadow-md);
+  transform: translateY(-1px);
 }
 
 .selection-toolbar-delete {

--- a/src/styles.css
+++ b/src/styles.css
@@ -1596,3 +1596,99 @@ header h1 {
   font-size: 14px;
   text-align: right;
 }
+
+/* =========================================================================
+   複数選択 (selection)
+   ========================================================================= */
+.bookmark-item.selected {
+  background-color: var(--accent-soft);
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm);
+}
+
+.bookmark-item.selected .bookmark-link {
+  color: var(--accent-strong);
+}
+
+.bookmark-item.selected .bookmark-link:hover {
+  background-color: var(--accent-soft-strong);
+}
+
+.selection-toolbar {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--shadow-lg);
+  z-index: 1000;
+  font-size: 14px;
+}
+
+.selection-toolbar-count {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.selection-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.selection-toolbar-btn {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 6px 14px;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  font-size: 13px;
+  transition: background-color var(--transition), color var(--transition),
+    border-color var(--transition);
+}
+
+.selection-toolbar-btn:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-strong);
+}
+
+.selection-toolbar-move {
+  background: var(--accent-gradient);
+  color: var(--accent-contrast);
+  border-color: transparent;
+}
+
+.selection-toolbar-move:hover {
+  filter: brightness(1.05);
+}
+
+.selection-toolbar-delete {
+  color: var(--danger);
+  border-color: rgba(220, 38, 38, 0.3);
+}
+
+.selection-toolbar-delete:hover {
+  background: rgba(220, 38, 38, 0.12);
+  border-color: var(--danger);
+}
+
+.selection-toolbar-clear {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  line-height: 1;
+  border-radius: 50%;
+}

--- a/test/bookmark-selection.test.ts
+++ b/test/bookmark-selection.test.ts
@@ -1,0 +1,314 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BookmarkSelection } from '../src/components/BookmarkSelection/BookmarkSelection';
+
+/**
+ * 複数選択ロジックのテスト。
+ *
+ * BookmarkSelection は次の動作を提供する:
+ * - 修飾キーなしクリック: 選択がなければ通常クリック (consumed=false)、
+ *   既に選択があれば選択解除のみ (consumed=true)
+ * - Shift+クリック: 直前のアンカーから範囲選択 (アンカーなしなら単一選択)
+ * - Cmd/Ctrl+クリック: PR #68 の「新タブで開く」に譲るため選択処理しない (consumed=false)
+ * - 非連続な追加は selection.toggle() を直接呼ぶ (UI ではコンテキストメニュー等から)
+ * - ESC: 選択解除
+ * - bulkDelete / bulkMove: 確認ダイアログを経由して Chrome API を呼ぶ
+ */
+describe('BookmarkSelection', () => {
+  let dom: JSDOM;
+  let container: HTMLElement;
+  let selection: BookmarkSelection;
+
+  /**
+   * テスト用に 3 つのブックマークアイテムを構築する。
+   */
+  function buildContainer(): HTMLElement {
+    const div = document.createElement('div');
+    div.innerHTML = `
+      <ul class="bookmark-list">
+        <li class="bookmark-item">
+          <a class="bookmark-link" data-url="https://a.example.com" href="#">
+            <span class="bookmark-title">A</span>
+          </a>
+        </li>
+        <li class="bookmark-item">
+          <a class="bookmark-link" data-url="https://b.example.com" href="#">
+            <span class="bookmark-title">B</span>
+          </a>
+        </li>
+        <li class="bookmark-item">
+          <a class="bookmark-link" data-url="https://c.example.com" href="#">
+            <span class="bookmark-title">C</span>
+          </a>
+        </li>
+      </ul>
+    `;
+    document.body.appendChild(div);
+    return div;
+  }
+
+  function clickEvent(
+    modifiers: { shiftKey?: boolean; metaKey?: boolean; ctrlKey?: boolean } = {}
+  ): MouseEvent {
+    return new dom.window.MouseEvent('click', {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: modifiers.shiftKey ?? false,
+      metaKey: modifiers.metaKey ?? false,
+      ctrlKey: modifiers.ctrlKey ?? false,
+    }) as unknown as MouseEvent;
+  }
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`, {
+      url: 'chrome-extension://test/newtab.html',
+    });
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CSS', {
+      value: dom.window.CSS,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'HTMLElement', {
+      value: dom.window.HTMLElement,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'KeyboardEvent', {
+      value: dom.window.KeyboardEvent,
+      writable: true,
+      configurable: true,
+    });
+
+    container = buildContainer();
+    selection = new BookmarkSelection();
+    selection.initialize(container);
+
+    // Chrome API モック
+    const mockChrome = globalThis.chrome as any;
+    mockChrome.bookmarks.search = vi.fn();
+    mockChrome.bookmarks.remove = vi.fn();
+    mockChrome.bookmarks.move = vi.fn();
+    mockChrome.bookmarks.create = vi.fn();
+    mockChrome.bookmarks.getTree = vi.fn().mockResolvedValue([
+      {
+        id: '0',
+        title: '',
+        children: [
+          { id: '1', title: 'ブックマークバー', children: [] },
+          { id: '2', title: 'その他のブックマーク', children: [] },
+        ],
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  function itemAt(index: number): HTMLElement {
+    return container.querySelectorAll('.bookmark-item')[index] as HTMLElement;
+  }
+
+  function urlAt(index: number): string {
+    const link = container.querySelectorAll('.bookmark-link')[index];
+    return link.getAttribute('data-url') ?? '';
+  }
+
+  it('修飾キーなし・未選択時は consumed=false で通常クリックを通す', () => {
+    const item = itemAt(0);
+    const consumed = selection.handleClick(urlAt(0), 'A', item, clickEvent());
+    expect(consumed).toBe(false);
+    expect(selection.count).toBe(0);
+  });
+
+  it('Cmd+クリックは consumed=false で新タブ動作 (#68) に譲る', () => {
+    const consumed = selection.handleClick(
+      urlAt(0),
+      'A',
+      itemAt(0),
+      clickEvent({ metaKey: true })
+    );
+    expect(consumed).toBe(false);
+    expect(selection.count).toBe(0);
+  });
+
+  it('Ctrl+クリックも同様に新タブ動作に譲る (consumed=false)', () => {
+    const consumed = selection.handleClick(
+      urlAt(0),
+      'A',
+      itemAt(0),
+      clickEvent({ ctrlKey: true })
+    );
+    expect(consumed).toBe(false);
+    expect(selection.count).toBe(0);
+  });
+
+  it('toggle() で非連続な選択を構築できる', () => {
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+    selection.toggle(urlAt(2), 'C', itemAt(2));
+    expect(selection.count).toBe(2);
+    expect(selection.getSelectedUrls()).toEqual([urlAt(0), urlAt(2)]);
+
+    // 再度トグルすると解除される
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+    expect(selection.count).toBe(1);
+  });
+
+  it('Shift+クリックで範囲選択する', () => {
+    // 最初のアイテムを toggle で選択し、anchor を確立するため Shift+click を経由
+    selection.handleClick(
+      urlAt(0),
+      'A',
+      itemAt(0),
+      clickEvent({ shiftKey: true })
+    );
+    // Shift+クリックで 3 つ目まで範囲選択
+    selection.handleClick(
+      urlAt(2),
+      'C',
+      itemAt(2),
+      clickEvent({ shiftKey: true })
+    );
+    expect(selection.count).toBe(3);
+    expect(itemAt(0).classList.contains('selected')).toBe(true);
+    expect(itemAt(1).classList.contains('selected')).toBe(true);
+    expect(itemAt(2).classList.contains('selected')).toBe(true);
+  });
+
+  it('複数選択中に修飾キーなしクリックすると選択解除のみで consumed=true', () => {
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+    selection.toggle(urlAt(1), 'B', itemAt(1));
+    expect(selection.count).toBe(2);
+
+    const consumed = selection.handleClick(
+      urlAt(2),
+      'C',
+      itemAt(2),
+      clickEvent()
+    );
+    expect(consumed).toBe(true);
+    expect(selection.count).toBe(0);
+  });
+
+  it('ESC キーで選択を解除する', () => {
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+    selection.toggle(urlAt(1), 'B', itemAt(1));
+    expect(selection.count).toBe(2);
+
+    const escEvent = new dom.window.KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    document.dispatchEvent(escEvent as unknown as Event);
+
+    expect(selection.count).toBe(0);
+  });
+
+  it('選択件数が 1 件以上のときフローティングツールバーを表示する', () => {
+    expect(document.querySelector('.selection-toolbar')).toBeNull();
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+    const toolbar = document.querySelector('.selection-toolbar');
+    expect(toolbar).not.toBeNull();
+    expect(toolbar?.textContent).toContain('1 件選択中');
+
+    selection.toggle(urlAt(1), 'B', itemAt(1));
+    expect(
+      document.querySelector('.selection-toolbar-count')?.textContent
+    ).toContain('2 件選択中');
+
+    selection.clear();
+    expect(document.querySelector('.selection-toolbar')).toBeNull();
+  });
+
+  it('一括削除を実行すると確認ダイアログを経て chrome.bookmarks.remove を呼ぶ', async () => {
+    const mockChrome = globalThis.chrome as any;
+    mockChrome.bookmarks.search.mockImplementation(({ url }: { url: string }) =>
+      Promise.resolve([
+        { id: `id-${url}`, parentId: '1', index: 0, title: url, url },
+      ])
+    );
+    mockChrome.bookmarks.remove.mockResolvedValue(undefined);
+
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+    selection.toggle(urlAt(1), 'B', itemAt(1));
+
+    const deletePromise = selection.bulkDelete();
+
+    // 確認ダイアログが出るまで待機
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const dialog = document.getElementById('bulk-confirm-dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.textContent).toContain('2 件');
+
+    (dialog?.querySelector('.delete-dialog-confirm') as HTMLElement).click();
+    await deletePromise;
+
+    expect(mockChrome.bookmarks.remove).toHaveBeenCalledTimes(2);
+    expect(selection.count).toBe(0);
+  });
+
+  it('一括削除をキャンセルすると Chrome API は呼ばれない', async () => {
+    const mockChrome = globalThis.chrome as any;
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+
+    const deletePromise = selection.bulkDelete();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const dialog = document.getElementById('bulk-confirm-dialog');
+    (dialog?.querySelector('.edit-dialog-cancel') as HTMLElement).click();
+    await deletePromise;
+
+    expect(mockChrome.bookmarks.remove).not.toHaveBeenCalled();
+    expect(selection.count).toBe(1);
+  });
+
+  it('一括移動はダイアログで親フォルダを選択し chrome.bookmarks.move を呼ぶ', async () => {
+    const mockChrome = globalThis.chrome as any;
+    mockChrome.bookmarks.search.mockImplementation(({ url }: { url: string }) =>
+      Promise.resolve([
+        { id: `id-${url}`, parentId: '1', index: 0, title: url, url },
+      ])
+    );
+    mockChrome.bookmarks.move.mockResolvedValue(undefined);
+
+    selection.toggle(urlAt(0), 'A', itemAt(0));
+    selection.toggle(urlAt(1), 'B', itemAt(1));
+
+    const movePromise = selection.bulkMove();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const dialog = document.getElementById('bulk-move-dialog');
+    expect(dialog).not.toBeNull();
+
+    const select = dialog?.querySelector(
+      '#bulk-move-parent'
+    ) as HTMLSelectElement;
+    select.value = '2';
+    (dialog?.querySelector('.bulk-move-confirm') as HTMLElement).click();
+    await movePromise;
+
+    expect(mockChrome.bookmarks.move).toHaveBeenCalledTimes(2);
+    expect(mockChrome.bookmarks.move).toHaveBeenCalledWith(
+      'id-https://a.example.com',
+      {
+        parentId: '2',
+      }
+    );
+    expect(selection.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `BookmarkSelection` を追加し、複数選択と一括操作を実装
- **Shift+クリック**で範囲選択（アンカーなしの場合は単一選択）
- 1件以上選択時にフローティングツールバー (`.selection-toolbar`) を表示
- ツールバーから一括削除・一括移動。Undo (Toast + Cmd/Ctrl+Z) 対応
- ESC で選択解除（モーダル表示中・入力欄フォーカス中は無効）
- ブックマーク項目に `.selected` の視覚スタイルを追加

## #68 との競合解決
PR #68 (Cmd/Ctrl+クリック = 新タブで開く) を優先。
- **Cmd/Ctrl+クリック**: 新タブで開く（選択処理しない）
- **Shift+クリック**: 範囲選択
- 非連続な追加選択は `BookmarkSelection.toggle()` API で利用可能。UI からの動線は今後コンテキストメニュー等で対応予定

## Test plan
- [x] `npm test` (202 tests passed)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: Shift+クリックで範囲選択
- [x] 実機: ツールバーから一括削除→Undo で復元
- [x] 実機: ツールバーから一括移動
- [x] 実機: ESC で選択解除
- [x] 実機: Cmd/Ctrl+クリックは新タブで開く動作のまま

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)