### PR TITLE
新規フォルダ作成の親候補から id=0 のルートを除外

### DIFF
--- a/src/components/BookmarkActions/FolderCreator.ts
+++ b/src/components/BookmarkActions/FolderCreator.ts
@@ -27,7 +27,11 @@ export class FolderCreator {
     const collect = (nodes: ChromeBookmarkNode[]) => {
       for (const node of nodes) {
         if (node.children && !node.url) {
-          folders.push(node);
+          // id='0' はツリーの仮想ルートで、ここを親に指定した chrome.bookmarks.create
+          // は失敗するため候補から除外する
+          if (node.id !== '0') {
+            folders.push(node);
+          }
           collect(node.children);
         }
       }


### PR DESCRIPTION
## Summary
新規フォルダ作成ダイアログの親フォルダ選択肢に「(ルート: 0)」が表示されていた問題を修正。

Chrome ブックマークツリーの仮想ルート (id=0) を親に指定した \`chrome.bookmarks.create\` は失敗するため、選択肢から除外する。

PR #70 の一括移動ダイアログでも同じ修正を実施済み。

## Test plan
- [x] \`npm test\`
- [x] \`npm run build:extension\`
- [x] 実機: フォルダ右クリック→「新規サブフォルダ」のダイアログで親フォルダ選択肢にルートが含まれていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)