### PR TITLE
ドラッグ中の autoscroll 対応 (#55)

### DIFF
--- a/src/components/BookmarkDragAndDrop/Autoscroller.ts
+++ b/src/components/BookmarkDragAndDrop/Autoscroller.ts
@@ -1,0 +1,81 @@
+/**
+ * ドラッグ中に画面の上端・下端付近にカーソルが来たとき、自動でウィンドウを
+ * スクロールするヘルパー。requestAnimationFrame で滑らかに動作する。
+ *
+ * 速度はエッジからの距離に応じてリニアに変化する:
+ *   - エッジまで EDGE_THRESHOLD_PX 以内: 加速
+ *   - エッジまで MIN_DISTANCE_PX 以内: 最大速度 MAX_SPEED_PX_PER_FRAME
+ */
+const EDGE_THRESHOLD_PX = 80;
+const MIN_DISTANCE_PX = 8;
+const MAX_SPEED_PX_PER_FRAME = 18;
+
+export class Autoscroller {
+  private rafId: number | null = null;
+  private currentSpeed = 0;
+
+  /**
+   * カーソル位置に応じてオートスクロールを更新する。
+   * ドラッグ中に dragover イベント等から繰り返し呼ぶ。
+   */
+  update(clientY: number, viewportHeight: number): void {
+    const speed = this.computeSpeed(clientY, viewportHeight);
+    this.currentSpeed = speed;
+    if (speed === 0) {
+      this.stop();
+      return;
+    }
+    if (this.rafId === null) {
+      this.startLoop();
+    }
+  }
+
+  /**
+   * オートスクロールを停止する。dragend / drop / dragleave 時に呼ぶ。
+   */
+  stop(): void {
+    this.currentSpeed = 0;
+    if (this.rafId !== null) {
+      window.cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
+  /**
+   * 現在の速度 (px/frame, 正: 下方向 / 負: 上方向)。テスト用に公開。
+   */
+  getSpeed(): number {
+    return this.currentSpeed;
+  }
+
+  private computeSpeed(clientY: number, viewportHeight: number): number {
+    const fromTop = clientY;
+    const fromBottom = viewportHeight - clientY;
+
+    if (fromTop < EDGE_THRESHOLD_PX) {
+      const distance = Math.max(fromTop, MIN_DISTANCE_PX);
+      const ratio =
+        (EDGE_THRESHOLD_PX - distance) / (EDGE_THRESHOLD_PX - MIN_DISTANCE_PX);
+      return -Math.round(MAX_SPEED_PX_PER_FRAME * ratio);
+    }
+    if (fromBottom < EDGE_THRESHOLD_PX) {
+      const distance = Math.max(fromBottom, MIN_DISTANCE_PX);
+      const ratio =
+        (EDGE_THRESHOLD_PX - distance) / (EDGE_THRESHOLD_PX - MIN_DISTANCE_PX);
+      return Math.round(MAX_SPEED_PX_PER_FRAME * ratio);
+    }
+    return 0;
+  }
+
+  private startLoop(): void {
+    const step = () => {
+      if (this.currentSpeed === 0) {
+        this.rafId = null;
+        return;
+      }
+      window.scrollBy(0, this.currentSpeed);
+      this.rafId = window.requestAnimationFrame(step);
+    };
+    this.rafId = window.requestAnimationFrame(step);
+  }
+}

--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -82,7 +82,6 @@ export class BookmarkDragAndDrop {
     // ドラッグ中の見た目を変更
     bookmarkLink.classList.add('dragging');
 
-    console.log('ドラッグ開始:', { url, title, folderId });
   }
 
   /**
@@ -111,7 +110,6 @@ export class BookmarkDragAndDrop {
 
     this.draggedBookmark = null;
     this.autoscroller.stop();
-    console.log('ドラッグ終了');
   }
 
   /**
@@ -196,13 +194,6 @@ export class BookmarkDragAndDrop {
     // ブックマーク移動処理を実行
     this.moveBookmark(this.draggedBookmark.url, targetFolderId)
       .then(() => {
-        console.log('ブックマーク移動成功:', {
-          from: this.draggedBookmark?.originalFolderId,
-          to: targetFolderId,
-          bookmark: this.draggedBookmark?.title,
-        });
-
-        // UIを更新
         this.refreshBookmarkList();
       })
       .catch((error) => {
@@ -237,11 +228,6 @@ export class BookmarkDragAndDrop {
       // ブックマークを移動
       await chrome.bookmarks.move(bookmark.id, {
         parentId: targetFolderId,
-      });
-
-      console.log('Chrome Bookmarks API: ブックマーク移動完了', {
-        bookmarkId: bookmark.id,
-        newParentId: targetFolderId,
       });
 
       // Undo 可能な操作として登録 (id は move では維持される)

--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -81,7 +81,6 @@ export class BookmarkDragAndDrop {
 
     // ドラッグ中の見た目を変更
     bookmarkLink.classList.add('dragging');
-
   }
 
   /**

--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -1,4 +1,5 @@
 import { UndoManager } from '../UndoManager/index.js';
+import { Autoscroller } from './Autoscroller.js';
 
 /**
  * ブックマークのドラッグ&ドロップ機能を管理するクラス
@@ -11,6 +12,7 @@ export class BookmarkDragAndDrop {
   } | null = null;
 
   private dropIndicator: HTMLElement | null = null;
+  private autoscroller: Autoscroller = new Autoscroller();
 
   /**
    * ドラッグ&ドロップ機能を初期化する
@@ -108,6 +110,7 @@ export class BookmarkDragAndDrop {
     }
 
     this.draggedBookmark = null;
+    this.autoscroller.stop();
     console.log('ドラッグ終了');
   }
 
@@ -115,6 +118,11 @@ export class BookmarkDragAndDrop {
    * ドラッグオーバー時の処理
    */
   private handleDragOver(event: DragEvent): void {
+    // ドラッグ中なら、フォルダ上かに関係なくオートスクロールを更新する
+    if (this.draggedBookmark) {
+      this.autoscroller.update(event.clientY, window.innerHeight);
+    }
+
     const target = event.target as HTMLElement;
     const folderHeader = target.closest('.folder-header') as HTMLElement;
 
@@ -166,6 +174,7 @@ export class BookmarkDragAndDrop {
    */
   private handleDrop(event: DragEvent): void {
     event.preventDefault();
+    this.autoscroller.stop();
 
     const target = event.target as HTMLElement;
     const folderHeader = target.closest('.folder-header') as HTMLElement;

--- a/test/autoscroller.test.ts
+++ b/test/autoscroller.test.ts
@@ -1,0 +1,107 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Autoscroller } from '../src/components/BookmarkDragAndDrop/Autoscroller';
+
+describe('Autoscroller', () => {
+  let dom: JSDOM;
+  let scrollBySpy: ReturnType<typeof vi.fn>;
+  let rafCallbacks: Array<() => void>;
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+
+    scrollBySpy = vi.fn();
+    rafCallbacks = [];
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        scrollBy: scrollBySpy,
+        requestAnimationFrame: (cb: () => void) => {
+          rafCallbacks.push(cb);
+          return rafCallbacks.length;
+        },
+        cancelAnimationFrame: vi.fn(),
+        innerHeight: 800,
+      },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  function tick(times: number): void {
+    for (let i = 0; i < times; i++) {
+      const cb = rafCallbacks.shift();
+      if (cb) cb();
+    }
+  }
+
+  it('画面中央付近では速度が 0 でスクロールしない', () => {
+    const scroller = new Autoscroller();
+    scroller.update(400, 800);
+    expect(scroller.getSpeed()).toBe(0);
+    tick(1);
+    expect(scrollBySpy).not.toHaveBeenCalled();
+  });
+
+  it('上端付近では負の速度 (上方向) でスクロールする', () => {
+    const scroller = new Autoscroller();
+    scroller.update(20, 800);
+    expect(scroller.getSpeed()).toBeLessThan(0);
+    tick(1);
+    expect(scrollBySpy).toHaveBeenCalledWith(0, expect.any(Number));
+    const [, dy] = scrollBySpy.mock.calls[0];
+    expect(dy).toBeLessThan(0);
+  });
+
+  it('下端付近では正の速度 (下方向) でスクロールする', () => {
+    const scroller = new Autoscroller();
+    scroller.update(790, 800);
+    expect(scroller.getSpeed()).toBeGreaterThan(0);
+    tick(1);
+    expect(scrollBySpy).toHaveBeenCalledWith(0, expect.any(Number));
+    const [, dy] = scrollBySpy.mock.calls[0];
+    expect(dy).toBeGreaterThan(0);
+  });
+
+  it('エッジに近いほど速度が速くなる (リニア)', () => {
+    const scroller = new Autoscroller();
+    scroller.update(70, 800);
+    const slowSpeed = Math.abs(scroller.getSpeed());
+
+    scroller.update(20, 800);
+    const fastSpeed = Math.abs(scroller.getSpeed());
+
+    expect(fastSpeed).toBeGreaterThan(slowSpeed);
+  });
+
+  it('stop() で速度が 0 になりスクロールが止まる', () => {
+    const scroller = new Autoscroller();
+    scroller.update(20, 800);
+    expect(scroller.getSpeed()).toBeLessThan(0);
+
+    scroller.stop();
+    expect(scroller.getSpeed()).toBe(0);
+    rafCallbacks.length = 0;
+    tick(1);
+    expect(scrollBySpy).not.toHaveBeenCalled();
+  });
+
+  it('エッジから離れる位置に update すると速度が 0 に戻る', () => {
+    const scroller = new Autoscroller();
+    scroller.update(20, 800);
+    expect(scroller.getSpeed()).not.toBe(0);
+
+    scroller.update(400, 800);
+    expect(scroller.getSpeed()).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- `Autoscroller` を追加。ドラッグ中に画面端 (80px) にカーソルが来たら自動スクロール
- 速度はエッジからの距離に応じてリニアに変化（最大 18px/frame）
- `requestAnimationFrame` で滑らかに動作
- `dragend` / `drop` / 中央に戻ったときに停止

## 変更
- 新規: `src/components/BookmarkDragAndDrop/Autoscroller.ts`
- 変更: `src/components/BookmarkDragAndDrop/index.ts` で dragover/dragend/drop に組み込み
- 新規: `test/autoscroller.test.ts` (6 ケース)

## Test plan
- [x] `npm test` (208 tests passed)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: 長いブックマークリストでドラッグ中に画面上端/下端にカーソルを近づけて自動スクロールを確認
- [x] 実機: ドロップ完了時にスクロールが止まる

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)