### PR TITLE
ドラッグプレビュー・ドロップターゲットの視覚改善 (#56)

### DIFF
--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -81,6 +81,72 @@ export class BookmarkDragAndDrop {
 
     // ドラッグ中の見た目を変更
     bookmarkLink.classList.add('dragging');
+
+    // カスタムドラッグプレビューを設定
+    this.setCustomDragImage(event, bookmarkLink, title);
+
+    // ドラッグ中であることを示すクラスを body に付与 (ドロップ可/不可の視覚化用)
+    document.body.classList.add('dragging-bookmark');
+    folderElement.classList.add('drag-source-folder');
+  }
+
+  /**
+   * ドラッグ画像をカスタマイズする。
+   * favicon + タイトル + (複数選択中なら) 件数バッジを表示する。
+   */
+  private setCustomDragImage(
+    event: DragEvent,
+    bookmarkLink: HTMLElement,
+    title: string
+  ): void {
+    if (!event.dataTransfer) return;
+
+    // 選択件数 (multi-select との連携): DOM ベースで判定
+    const selectedCount = document.querySelectorAll(
+      '.bookmark-item.selected'
+    ).length;
+
+    const preview = document.createElement('div');
+    preview.className = 'bookmark-drag-preview';
+
+    // favicon を取得 (存在しない場合は絵文字フォールバック)
+    const faviconImg = bookmarkLink.querySelector(
+      '.bookmark-favicon'
+    ) as HTMLImageElement | null;
+    const faviconSrc = faviconImg?.src;
+    const faviconHtml =
+      faviconSrc && !faviconImg?.classList.contains('hidden')
+        ? `<img src="${faviconSrc}" alt="" class="bookmark-drag-preview-icon" />`
+        : `<span class="bookmark-drag-preview-icon-placeholder">🔗</span>`;
+
+    const badgeHtml =
+      selectedCount > 1
+        ? `<span class="bookmark-drag-preview-badge">${selectedCount}</span>`
+        : '';
+
+    preview.innerHTML = `
+      ${faviconHtml}
+      <span class="bookmark-drag-preview-title"></span>
+      ${badgeHtml}
+    `;
+    // タイトルは textContent で安全に設定
+    const titleEl = preview.querySelector('.bookmark-drag-preview-title');
+    if (titleEl) {
+      titleEl.textContent = title;
+    }
+
+    // 画面外に配置してから setDragImage に渡す (描画されないとブラウザが画像化できない)
+    preview.style.position = 'absolute';
+    preview.style.top = '-1000px';
+    preview.style.left = '-1000px';
+    document.body.appendChild(preview);
+
+    event.dataTransfer.setDragImage(preview, 16, 16);
+
+    // 次フレームで掃除する
+    requestAnimationFrame(() => {
+      preview.remove();
+    });
   }
 
   /**
@@ -109,6 +175,19 @@ export class BookmarkDragAndDrop {
 
     this.draggedBookmark = null;
     this.autoscroller.stop();
+
+    // ドラッグ状態の視覚的マーカーを除去
+    document.body.classList.remove('dragging-bookmark');
+    for (const el of Array.from(
+      document.querySelectorAll('.drag-source-folder')
+    )) {
+      el.classList.remove('drag-source-folder');
+    }
+    for (const el of Array.from(
+      document.querySelectorAll('.drop-target-invalid')
+    )) {
+      el.classList.remove('drop-target-invalid');
+    }
   }
 
   /**
@@ -130,8 +209,12 @@ export class BookmarkDragAndDrop {
     ) as HTMLElement;
     const targetFolderId = folderElement?.dataset.folderId;
 
-    // 同じフォルダへのドロップは無効
+    // 同じフォルダへのドロップは無効: 不可視覚を表示するため invalid クラスを付与
     if (targetFolderId === this.draggedBookmark.originalFolderId) {
+      folderHeader.classList.add('drop-target-invalid');
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'none';
+      }
       return;
     }
 
@@ -163,6 +246,7 @@ export class BookmarkDragAndDrop {
 
     if (folderHeader) {
       folderHeader.classList.remove('drop-target-highlight');
+      folderHeader.classList.remove('drop-target-invalid');
     }
   }
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -540,6 +540,76 @@ header h1 {
   transition: all 0.2s ease;
 }
 
+/* ドロップ不可ターゲット (ドラッグ元と同じフォルダなど) */
+.folder-header.drop-target-invalid {
+  background: rgba(220, 38, 38, 0.08);
+  border: 2px dashed var(--danger);
+  border-radius: var(--radius-sm);
+  cursor: not-allowed;
+}
+
+/* ドラッグ中の元フォルダを薄く表示 */
+body.dragging-bookmark .bookmark-folder.drag-source-folder {
+  opacity: 0.7;
+}
+
+/* ドラッグ中、ドロップ可能なフォルダのホバーを示唆 */
+body.dragging-bookmark .bookmark-folder:not(.drag-source-folder) .folder-header {
+  transition: background-color 0.2s ease, border-color 0.2s ease;
+}
+
+/* カスタムドラッグプレビュー */
+.bookmark-drag-preview {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  background: var(--surface);
+  color: var(--text);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-lg);
+  font-size: 13px;
+  font-weight: 500;
+  max-width: 320px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bookmark-drag-preview-icon {
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+}
+
+.bookmark-drag-preview-icon-placeholder {
+  font-size: 16px;
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.bookmark-drag-preview-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bookmark-drag-preview-badge {
+  background: var(--accent-gradient);
+  color: var(--accent-contrast);
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
 .bookmark-drop-indicator {
   background: var(--accent);
   color: var(--accent-contrast);

--- a/src/styles.css
+++ b/src/styles.css
@@ -535,9 +535,10 @@ header h1 {
 
 .folder-header.drop-target-highlight {
   background: var(--accent-soft-strong);
+  /* border-color の transition で currentColor からの白っぽい補間が発生して
+     チラつくため、border は即時適用にする (transition プロパティは指定しない) */
   border: 2px dashed var(--accent);
   border-radius: var(--radius-sm);
-  transition: all 0.2s ease;
 }
 
 /* ドロップ不可ターゲット (ドラッグ元と同じフォルダなど) */
@@ -551,11 +552,6 @@ header h1 {
 /* ドラッグ中の元フォルダを薄く表示 */
 body.dragging-bookmark .bookmark-folder.drag-source-folder {
   opacity: 0.7;
-}
-
-/* ドラッグ中、ドロップ可能なフォルダのホバーを示唆 */
-body.dragging-bookmark .bookmark-folder:not(.drag-source-folder) .folder-header {
-  transition: background-color 0.2s ease, border-color 0.2s ease;
 }
 
 /* カスタムドラッグプレビュー */

--- a/test/drag-preview.test.ts
+++ b/test/drag-preview.test.ts
@@ -1,0 +1,181 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BookmarkDragAndDrop } from '../src/components/BookmarkDragAndDrop/index';
+
+describe('BookmarkDragAndDrop — ドラッグプレビューとドロップ視覚', () => {
+  let dom: JSDOM;
+  let dnd: BookmarkDragAndDrop;
+
+  function buildDom(): void {
+    document.body.innerHTML = `
+      <div class="bookmark-container">
+        <div class="bookmark-folder" data-folder-id="src-folder">
+          <div class="folder-header has-subfolders">
+            <h2 class="folder-title">元フォルダ</h2>
+          </div>
+          <ul class="bookmark-list">
+            <li class="bookmark-item">
+              <a class="bookmark-link" data-url="https://a.example.com" draggable="true">
+                <img class="bookmark-favicon" src="https://a.example.com/icon.png" />
+                <span class="bookmark-title">A</span>
+              </a>
+            </li>
+          </ul>
+        </div>
+        <div class="bookmark-folder" data-folder-id="dst-folder">
+          <div class="folder-header has-subfolders">
+            <h2 class="folder-title">移動先</h2>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function createDragEvent(
+    type: string,
+    target: HTMLElement,
+    overrides: Partial<DragEvent> = {}
+  ): DragEvent {
+    const event = new dom.window.Event(type, {
+      bubbles: true,
+      cancelable: true,
+    }) as unknown as DragEvent;
+    Object.defineProperty(event, 'target', { value: target });
+    Object.defineProperty(event, 'dataTransfer', {
+      value: {
+        setData: vi.fn(),
+        setDragImage: vi.fn(),
+        effectAllowed: '',
+        dropEffect: '',
+      },
+    });
+    for (const [k, v] of Object.entries(overrides)) {
+      Object.defineProperty(event, k, { value: v });
+    }
+    return event;
+  }
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      value: (cb: () => void) => {
+        cb();
+        return 0;
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    buildDom();
+    dnd = new BookmarkDragAndDrop();
+    dnd.initialize();
+  });
+
+  afterEach(() => {
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('ドラッグ開始時にカスタムドラッグプレビューが setDragImage に渡される', () => {
+    const link = document.querySelector('.bookmark-link') as HTMLElement;
+    const event = createDragEvent('dragstart', link);
+    document.dispatchEvent(event);
+
+    expect(event.dataTransfer?.setDragImage).toHaveBeenCalled();
+    // body にドラッグ状態マーカーが付与される
+    expect(document.body.classList.contains('dragging-bookmark')).toBe(true);
+    // 元フォルダにマーカー
+    expect(
+      document
+        .querySelector('[data-folder-id="src-folder"]')
+        ?.classList.contains('drag-source-folder')
+    ).toBe(true);
+  });
+
+  it('複数選択時はプレビューに件数バッジが含まれる', () => {
+    // 2 件を選択状態にする
+    const items = document.querySelectorAll('.bookmark-item');
+    for (const item of Array.from(items)) {
+      item.classList.add('selected');
+    }
+    // ダミーで .bookmark-item.selected を計2件にする
+    const extra = document.createElement('li');
+    extra.className = 'bookmark-item selected';
+    document.body.appendChild(extra);
+
+    const link = document.querySelector('.bookmark-link') as HTMLElement;
+    const event = createDragEvent('dragstart', link);
+
+    // setDragImage に渡される preview 要素を捕捉する
+    let capturedPreview: HTMLElement | null = null;
+    (
+      event.dataTransfer as unknown as { setDragImage: typeof vi.fn }
+    ).setDragImage = vi.fn((el: HTMLElement) => {
+      capturedPreview = el;
+    });
+
+    document.dispatchEvent(event);
+
+    expect(capturedPreview).not.toBeNull();
+    expect(
+      (capturedPreview as unknown as HTMLElement)?.querySelector(
+        '.bookmark-drag-preview-badge'
+      )
+    ).not.toBeNull();
+  });
+
+  it('元フォルダ上の dragover で drop-target-invalid が付与される', () => {
+    const link = document.querySelector('.bookmark-link') as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', link));
+
+    const srcHeader = document.querySelector(
+      '[data-folder-id="src-folder"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', srcHeader));
+
+    expect(srcHeader.classList.contains('drop-target-invalid')).toBe(true);
+    expect(srcHeader.classList.contains('drop-target-highlight')).toBe(false);
+  });
+
+  it('別フォルダ上の dragover で drop-target-highlight が付与される', () => {
+    const link = document.querySelector('.bookmark-link') as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', link));
+
+    const dstHeader = document.querySelector(
+      '[data-folder-id="dst-folder"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', dstHeader));
+
+    expect(dstHeader.classList.contains('drop-target-highlight')).toBe(true);
+    expect(dstHeader.classList.contains('drop-target-invalid')).toBe(false);
+  });
+
+  it('dragend で全てのドラッグ状態マーカーが除去される', () => {
+    const link = document.querySelector('.bookmark-link') as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', link));
+    const srcHeader = document.querySelector(
+      '[data-folder-id="src-folder"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', srcHeader));
+
+    document.dispatchEvent(createDragEvent('dragend', link));
+
+    expect(document.body.classList.contains('dragging-bookmark')).toBe(false);
+    expect(srcHeader.classList.contains('drop-target-invalid')).toBe(false);
+    expect(
+      document
+        .querySelector('[data-folder-id="src-folder"]')
+        ?.classList.contains('drag-source-folder')
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- **カスタムドラッグプレビュー**: favicon + タイトル + (複数選択時) 件数バッジを `setDragImage` に渡す
- **ドロップ可ターゲット**: 既存の `.drop-target-highlight` (accent 色)
- **ドロップ不可ターゲット (ドラッグ元と同じフォルダ)**: `.drop-target-invalid` を danger 色で表現、`dropEffect='none'` を設定
- **ドラッグ中の元フォルダ**: 薄く表示 (`.drag-source-folder` + `body.dragging-bookmark`)
- 複数選択件数は DOM の `.bookmark-item.selected` 数から取得し `BookmarkSelection` と疎結合

## Test plan
- [x] `npm test` (213 tests passed)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: ドラッグ時にカスタムプレビューが表示される
- [x] 実機: 複数選択して 1つをドラッグすると件数バッジが出る
- [x] 実機: 別フォルダ上で accent 色のハイライト
- [x] 実機: 元フォルダ上で danger 色のハイライト

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)