### PR TITLE
フォルダ自体の DnD 移動 (#54)

### DIFF
--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -11,6 +11,12 @@ export class BookmarkDragAndDrop {
     originalFolderId: string;
   } | null = null;
 
+  private draggedFolder: {
+    id: string;
+    title: string;
+    sourceElement: HTMLElement;
+  } | null = null;
+
   private dropIndicator: HTMLElement | null = null;
   private autoscroller: Autoscroller = new Autoscroller();
 
@@ -49,6 +55,16 @@ export class BookmarkDragAndDrop {
    */
   private handleDragStart(event: DragEvent): void {
     const target = event.target as HTMLElement;
+
+    // フォルダヘッダーからのドラッグはフォルダ移動として処理する
+    const folderHeaderSource = target.closest(
+      '.folder-header[draggable="true"]'
+    ) as HTMLElement | null;
+    if (folderHeaderSource) {
+      this.handleFolderDragStart(event, folderHeaderSource);
+      return;
+    }
+
     const bookmarkLink = target.closest('.bookmark-link') as HTMLElement;
 
     if (!bookmarkLink) return;
@@ -174,10 +190,12 @@ export class BookmarkDragAndDrop {
     }
 
     this.draggedBookmark = null;
+    this.draggedFolder = null;
     this.autoscroller.stop();
 
     // ドラッグ状態の視覚的マーカーを除去
     document.body.classList.remove('dragging-bookmark');
+    document.body.classList.remove('dragging-folder');
     for (const el of Array.from(
       document.querySelectorAll('.drag-source-folder')
     )) {
@@ -188,6 +206,11 @@ export class BookmarkDragAndDrop {
     )) {
       el.classList.remove('drop-target-invalid');
     }
+    for (const el of Array.from(
+      document.querySelectorAll('.folder-header.dragging')
+    )) {
+      el.classList.remove('dragging');
+    }
   }
 
   /**
@@ -195,12 +218,17 @@ export class BookmarkDragAndDrop {
    */
   private handleDragOver(event: DragEvent): void {
     // ドラッグ中なら、フォルダ上かに関係なくオートスクロールを更新する
-    if (this.draggedBookmark) {
+    if (this.draggedBookmark || this.draggedFolder) {
       this.autoscroller.update(event.clientY, window.innerHeight);
     }
 
     const target = event.target as HTMLElement;
     const folderHeader = target.closest('.folder-header') as HTMLElement;
+
+    if (this.draggedFolder) {
+      this.handleFolderDragOver(event, folderHeader);
+      return;
+    }
 
     if (!folderHeader || !this.draggedBookmark) return;
 
@@ -259,6 +287,11 @@ export class BookmarkDragAndDrop {
 
     const target = event.target as HTMLElement;
     const folderHeader = target.closest('.folder-header') as HTMLElement;
+
+    if (this.draggedFolder) {
+      this.handleFolderDrop(event, folderHeader);
+      return;
+    }
 
     if (!folderHeader || !this.draggedBookmark) return;
 
@@ -360,6 +393,190 @@ export class BookmarkDragAndDrop {
       linkElement.draggable = true;
       linkElement.setAttribute('draggable', 'true');
     }
+  }
+
+  // ===========================================================================
+  // フォルダ DnD (#54)
+  // ===========================================================================
+
+  /**
+   * フォルダのドラッグ開始処理
+   */
+  private handleFolderDragStart(
+    event: DragEvent,
+    folderHeader: HTMLElement
+  ): void {
+    const folderElement = folderHeader.closest(
+      '.bookmark-folder'
+    ) as HTMLElement | null;
+    const folderId = folderElement?.dataset.folderId;
+    const title =
+      folderHeader.querySelector('.folder-title')?.textContent ?? '';
+
+    if (!folderElement || !folderId) return;
+
+    this.draggedFolder = {
+      id: folderId,
+      title,
+      sourceElement: folderElement,
+    };
+
+    if (event.dataTransfer) {
+      event.dataTransfer.setData('text/plain', folderId);
+      event.dataTransfer.setData(
+        'application/x-bookmark-folder-source',
+        folderId
+      );
+      event.dataTransfer.effectAllowed = 'move';
+    }
+
+    folderHeader.classList.add('dragging');
+    document.body.classList.add('dragging-bookmark');
+    document.body.classList.add('dragging-folder');
+    folderElement.classList.add('drag-source-folder');
+
+    this.setCustomFolderDragImage(event, title);
+  }
+
+  private setCustomFolderDragImage(event: DragEvent, title: string): void {
+    if (!event.dataTransfer) return;
+
+    const preview = document.createElement('div');
+    preview.className = 'bookmark-drag-preview folder-drag-preview';
+    preview.innerHTML = `
+      <span class="bookmark-drag-preview-icon-placeholder">📁</span>
+      <span class="bookmark-drag-preview-title"></span>
+    `;
+    const titleEl = preview.querySelector('.bookmark-drag-preview-title');
+    if (titleEl) titleEl.textContent = title;
+
+    preview.style.position = 'absolute';
+    preview.style.top = '-1000px';
+    preview.style.left = '-1000px';
+    document.body.appendChild(preview);
+
+    event.dataTransfer.setDragImage(preview, 16, 16);
+
+    requestAnimationFrame(() => {
+      preview.remove();
+    });
+  }
+
+  /**
+   * フォルダのドラッグオーバー処理
+   */
+  private handleFolderDragOver(
+    event: DragEvent,
+    folderHeader: HTMLElement | null
+  ): void {
+    if (!folderHeader || !this.draggedFolder) return;
+
+    const targetFolderElement = folderHeader.closest(
+      '.bookmark-folder'
+    ) as HTMLElement | null;
+    if (!targetFolderElement) return;
+
+    const targetFolderId = targetFolderElement.dataset.folderId;
+    if (!targetFolderId) return;
+
+    const sourceElement = this.draggedFolder.sourceElement;
+
+    // 自分自身、または自分の子孫へのドロップは禁止
+    const isSelfOrDescendant =
+      targetFolderElement === sourceElement ||
+      sourceElement.contains(targetFolderElement);
+
+    if (isSelfOrDescendant) {
+      folderHeader.classList.add('drop-target-invalid');
+      if (event.dataTransfer) {
+        event.dataTransfer.dropEffect = 'none';
+      }
+      return;
+    }
+
+    event.preventDefault();
+    if (event.dataTransfer) {
+      event.dataTransfer.dropEffect = 'move';
+    }
+    folderHeader.classList.add('drop-target-highlight');
+  }
+
+  /**
+   * フォルダのドロップ処理
+   */
+  private handleFolderDrop(
+    event: DragEvent,
+    folderHeader: HTMLElement | null
+  ): void {
+    const dragged = this.draggedFolder;
+    if (!dragged || !folderHeader) return;
+
+    const targetFolderElement = folderHeader.closest(
+      '.bookmark-folder'
+    ) as HTMLElement | null;
+    if (!targetFolderElement) return;
+    const targetFolderId = targetFolderElement.dataset.folderId;
+    if (!targetFolderId) return;
+
+    // 自分自身・子孫への移動は禁止
+    if (
+      targetFolderElement === dragged.sourceElement ||
+      dragged.sourceElement.contains(targetFolderElement)
+    ) {
+      return;
+    }
+
+    folderHeader.classList.remove('drop-target-highlight');
+
+    this.moveFolder(dragged.id, targetFolderId, dragged.title)
+      .then(() => {
+        this.dispatchBookmarksChanged('folder-move');
+      })
+      .catch((error) => {
+        console.error('フォルダ移動エラー:', error);
+        alert('フォルダの移動に失敗しました。');
+      });
+  }
+
+  /**
+   * Chrome Bookmarks API を使用してフォルダを移動する。Undo に対応する。
+   */
+  private async moveFolder(
+    folderId: string,
+    newParentId: string,
+    title: string
+  ): Promise<void> {
+    try {
+      const [node] = await chrome.bookmarks.get(folderId);
+      if (!node) {
+        throw new Error('移動対象のフォルダが見つかりません');
+      }
+      const originalParentId = node.parentId;
+      const originalIndex = node.index;
+
+      await chrome.bookmarks.move(folderId, { parentId: newParentId });
+
+      if (originalParentId !== undefined) {
+        UndoManager.getInstance().register({
+          message: `フォルダ「${title}」を移動しました`,
+          undo: async () => {
+            await chrome.bookmarks.move(folderId, {
+              parentId: originalParentId,
+              index: originalIndex,
+            });
+            this.dispatchBookmarksChanged('undo-folder-move');
+          },
+        });
+      }
+    } catch (error) {
+      console.error('Chrome Bookmarks API エラー:', error);
+      throw error;
+    }
+  }
+
+  private dispatchBookmarksChanged(action: string): void {
+    const event = new CustomEvent('bookmarks-changed', { detail: { action } });
+    document.dispatchEvent(event);
   }
 
   /**

--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -463,6 +463,28 @@ export class BookmarkDragAndDrop {
   }
 
   /**
+   * 移動先として無効なフォルダか判定する。
+   * - 自分自身: 同じ要素への移動
+   * - 自分の子孫: ループを防ぐ
+   * - 現在の親フォルダ: 実質変化なしの no-op を防ぐ
+   */
+  private isInvalidFolderDropTarget(
+    sourceElement: HTMLElement,
+    targetFolderElement: HTMLElement
+  ): boolean {
+    if (targetFolderElement === sourceElement) return true;
+    if (sourceElement.contains(targetFolderElement)) return true;
+
+    // 現在の親フォルダ (描画 DOM 上の最近接 .bookmark-folder 祖先) と一致するか
+    const currentParent = sourceElement.parentElement?.closest(
+      '.bookmark-folder'
+    ) as HTMLElement | null;
+    if (currentParent && currentParent === targetFolderElement) return true;
+
+    return false;
+  }
+
+  /**
    * フォルダのドラッグオーバー処理
    */
   private handleFolderDragOver(
@@ -481,12 +503,8 @@ export class BookmarkDragAndDrop {
 
     const sourceElement = this.draggedFolder.sourceElement;
 
-    // 自分自身、または自分の子孫へのドロップは禁止
-    const isSelfOrDescendant =
-      targetFolderElement === sourceElement ||
-      sourceElement.contains(targetFolderElement);
-
-    if (isSelfOrDescendant) {
+    // 自分自身・子孫・現在の親フォルダへのドロップは禁止 (実質変化なし)
+    if (this.isInvalidFolderDropTarget(sourceElement, targetFolderElement)) {
       folderHeader.classList.add('drop-target-invalid');
       if (event.dataTransfer) {
         event.dataTransfer.dropEffect = 'none';
@@ -518,10 +536,9 @@ export class BookmarkDragAndDrop {
     const targetFolderId = targetFolderElement.dataset.folderId;
     if (!targetFolderId) return;
 
-    // 自分自身・子孫への移動は禁止
+    // 自分自身・子孫・現在の親フォルダへの移動は禁止
     if (
-      targetFolderElement === dragged.sourceElement ||
-      dragged.sourceElement.contains(targetFolderElement)
+      this.isInvalidFolderDropTarget(dragged.sourceElement, targetFolderElement)
     ) {
       return;
     }

--- a/src/components/BookmarkFolder/BookmarkFolderRenderer.ts
+++ b/src/components/BookmarkFolder/BookmarkFolderRenderer.ts
@@ -48,8 +48,13 @@ export class BookmarkFolderRenderer {
         ? 'has-bookmarks'
         : '';
 
+    // Chrome のパーマネントフォルダ (id=1/2/3) はドラッグ不可
+    const isPermanent =
+      folder.id === '1' || folder.id === '2' || folder.id === '3';
+    const draggableAttr = isPermanent ? '' : 'draggable="true"';
+
     return `
-      <div class="folder-header ${headerClass}" tabindex="0" role="treeitem" aria-expanded="${folder.expanded ? 'true' : 'false'}">
+      <div class="folder-header ${headerClass}" tabindex="0" role="treeitem" aria-expanded="${folder.expanded ? 'true' : 'false'}" ${draggableAttr}>
         <div class="folder-info">
           ${this.renderFolderIcon(hasSubfolders, hasBookmarks, folder.expanded)}
           <h2 class="folder-title">${escapeHtml(folder.title)}</h2>

--- a/src/styles.css
+++ b/src/styles.css
@@ -554,6 +554,20 @@ body.dragging-bookmark .bookmark-folder.drag-source-folder {
   opacity: 0.7;
 }
 
+/* フォルダヘッダーをドラッグ中の見た目 */
+.folder-header[draggable='true'] {
+  cursor: grab;
+}
+
+.folder-header.dragging {
+  opacity: 0.5;
+}
+
+/* フォルダ DnD 中はカーソルを変えて視覚的に分かりやすく */
+body.dragging-folder {
+  cursor: grabbing;
+}
+
 /* カスタムドラッグプレビュー */
 .bookmark-drag-preview {
   display: inline-flex;

--- a/test/folder-dnd.test.ts
+++ b/test/folder-dnd.test.ts
@@ -1,0 +1,231 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BookmarkDragAndDrop } from '../src/components/BookmarkDragAndDrop/index';
+import { Toast } from '../src/components/Toast/index';
+import { UndoManager } from '../src/components/UndoManager/index';
+
+describe('BookmarkDragAndDrop — フォルダ DnD (#54)', () => {
+  let dom: JSDOM;
+  let dnd: BookmarkDragAndDrop;
+
+  function buildDom(): void {
+    document.body.innerHTML = `
+      <div class="bookmark-container">
+        <div class="bookmark-folder" data-folder-id="parent-A">
+          <div class="folder-header" draggable="true">
+            <h2 class="folder-title">親A</h2>
+          </div>
+          <div class="subfolders-container">
+            <div class="bookmark-folder" data-folder-id="child-A1">
+              <div class="folder-header" draggable="true">
+                <h2 class="folder-title">子A1</h2>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="bookmark-folder" data-folder-id="parent-B">
+          <div class="folder-header" draggable="true">
+            <h2 class="folder-title">親B</h2>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  function createDragEvent(type: string, target: HTMLElement): DragEvent {
+    const event = new dom.window.Event(type, {
+      bubbles: true,
+      cancelable: true,
+    }) as unknown as DragEvent;
+    Object.defineProperty(event, 'target', { value: target });
+    Object.defineProperty(event, 'dataTransfer', {
+      value: {
+        setData: vi.fn(),
+        setDragImage: vi.fn(),
+        effectAllowed: '',
+        dropEffect: '',
+      },
+      writable: true,
+    });
+    return event;
+  }
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      value: (cb: () => void) => {
+        cb();
+        return 0;
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: {
+        get: ReturnType<typeof vi.fn>;
+        move: ReturnType<typeof vi.fn>;
+      };
+    };
+    mockChrome.bookmarks.get = vi
+      .fn()
+      .mockResolvedValue([
+        { id: 'parent-A', parentId: '1', index: 0, title: '親A' },
+      ]);
+    mockChrome.bookmarks.move = vi.fn().mockResolvedValue(undefined);
+
+    buildDom();
+    dnd = new BookmarkDragAndDrop();
+    dnd.initialize();
+  });
+
+  afterEach(() => {
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('フォルダヘッダーから dragstart で body に dragging-folder クラスが付く', () => {
+    const header = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', header));
+
+    expect(document.body.classList.contains('dragging-folder')).toBe(true);
+    expect(header.classList.contains('dragging')).toBe(true);
+  });
+
+  it('別フォルダの上で dragover すると drop-target-highlight が付く', () => {
+    const sourceHeader = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', sourceHeader));
+
+    const targetHeader = document.querySelector(
+      '[data-folder-id="parent-B"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', targetHeader));
+
+    expect(targetHeader.classList.contains('drop-target-highlight')).toBe(true);
+    expect(targetHeader.classList.contains('drop-target-invalid')).toBe(false);
+  });
+
+  it('自分自身の上にドロップすると drop-target-invalid が付く', () => {
+    const sourceHeader = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', sourceHeader));
+    document.dispatchEvent(createDragEvent('dragover', sourceHeader));
+
+    expect(sourceHeader.classList.contains('drop-target-invalid')).toBe(true);
+    expect(sourceHeader.classList.contains('drop-target-highlight')).toBe(
+      false
+    );
+  });
+
+  it('自分の子孫の上にドロップすると drop-target-invalid が付く', () => {
+    const sourceHeader = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', sourceHeader));
+
+    const childHeader = document.querySelector(
+      '[data-folder-id="child-A1"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', childHeader));
+
+    expect(childHeader.classList.contains('drop-target-invalid')).toBe(true);
+    expect(childHeader.classList.contains('drop-target-highlight')).toBe(false);
+  });
+
+  it('別フォルダにドロップで chrome.bookmarks.move が呼ばれる', async () => {
+    const sourceHeader = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', sourceHeader));
+
+    const targetHeader = document.querySelector(
+      '[data-folder-id="parent-B"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', targetHeader));
+    document.dispatchEvent(createDragEvent('drop', targetHeader));
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('parent-A', {
+      parentId: 'parent-B',
+    });
+  });
+
+  it('子孫へのドロップでは chrome.bookmarks.move が呼ばれない', async () => {
+    const sourceHeader = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', sourceHeader));
+
+    const childHeader = document.querySelector(
+      '[data-folder-id="child-A1"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('drop', childHeader));
+
+    await new Promise((r) => setTimeout(r, 20));
+    expect(chrome.bookmarks.move).not.toHaveBeenCalled();
+  });
+
+  it('移動後 Undo Toast が表示され、Undo で元の位置に戻る', async () => {
+    const sourceHeader = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', sourceHeader));
+
+    const targetHeader = document.querySelector(
+      '[data-folder-id="parent-B"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', targetHeader));
+    document.dispatchEvent(createDragEvent('drop', targetHeader));
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+
+    (toast?.querySelector('.app-toast-action') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(chrome.bookmarks.move).toHaveBeenLastCalledWith('parent-A', {
+      parentId: '1',
+      index: 0,
+    });
+  });
+
+  it('dragend で全状態マーカーがリセットされる', () => {
+    const header = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', header));
+    document.dispatchEvent(createDragEvent('dragend', header));
+
+    expect(document.body.classList.contains('dragging-folder')).toBe(false);
+    expect(document.body.classList.contains('dragging-bookmark')).toBe(false);
+    expect(header.classList.contains('dragging')).toBe(false);
+  });
+});

--- a/test/folder-dnd.test.ts
+++ b/test/folder-dnd.test.ts
@@ -142,6 +142,28 @@ describe('BookmarkDragAndDrop — フォルダ DnD (#54)', () => {
     );
   });
 
+  it('子フォルダを現在の親フォルダ上にドロップしても無効 (no-op 防止)', () => {
+    // child-A1 (parent-A の子) を parent-A 上にドロップ
+    const childHeader = document.querySelector(
+      '[data-folder-id="child-A1"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', childHeader));
+
+    const parentHeader = document.querySelector(
+      '[data-folder-id="parent-A"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', parentHeader));
+
+    expect(parentHeader.classList.contains('drop-target-invalid')).toBe(true);
+    expect(parentHeader.classList.contains('drop-target-highlight')).toBe(
+      false
+    );
+
+    // drop しても move は呼ばれない
+    document.dispatchEvent(createDragEvent('drop', parentHeader));
+    expect(chrome.bookmarks.move).not.toHaveBeenCalled();
+  });
+
   it('自分の子孫の上にドロップすると drop-target-invalid が付く', () => {
     const sourceHeader = document.querySelector(
       '[data-folder-id="parent-A"] .folder-header'


### PR DESCRIPTION
## Summary
- **フォルダヘッダーを `draggable="true"`** に。パーマネントフォルダ (id=1/2/3) は除外
- 他フォルダのヘッダーにドロップで **サブフォルダ化** (`chrome.bookmarks.move`)
- **自分自身・自分の子孫への移動を禁止** (DOM の `contains` で判定)
- ドロップ可/不可の視覚フィードバック (PR #56 と統一)
- **Undo 対応**: 元の `parentId` / `index` に戻せる
- フォルダ用ドラッグプレビュー (📁 + タイトル)

## 範囲外 (フォローアップ予定)
フォルダ間の **並び替え (順序変更)** は本 PR の範囲外。drop 位置の上下判定 + index 指定の `chrome.bookmarks.move` での実装が必要で、別 issue として切り出すのが安全。

## Test plan
- [x] `npm test` (221 tests passed)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: フォルダのヘッダーをドラッグして別フォルダにドロップ
- [x] 実機: 自分自身/子孫へのドロップは無効
- [x] 実機: パーマネントフォルダはドラッグできない
- [x] 実機: Undo で元の位置に戻る

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)