### PR TITLE
ブックマーク間の並び替え (#80)

### DIFF
--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -207,9 +207,15 @@ export class BookmarkDragAndDrop {
       el.classList.remove('drop-target-invalid');
     }
     for (const el of Array.from(
-      document.querySelectorAll('.drop-zone-before, .drop-zone-after')
+      document.querySelectorAll(
+        '.drop-zone-before, .drop-zone-after, .bookmark-item.drop-target-invalid'
+      )
     )) {
-      el.classList.remove('drop-zone-before', 'drop-zone-after');
+      el.classList.remove(
+        'drop-zone-before',
+        'drop-zone-after',
+        'drop-target-invalid'
+      );
     }
     for (const el of Array.from(
       document.querySelectorAll('.folder-header.dragging')
@@ -235,7 +241,16 @@ export class BookmarkDragAndDrop {
       return;
     }
 
-    if (!folderHeader || !this.draggedBookmark) return;
+    if (!this.draggedBookmark) return;
+
+    // ブックマーク間 reorder のチェック (#80)
+    const bookmarkItem = target.closest('.bookmark-item') as HTMLElement | null;
+    if (bookmarkItem) {
+      this.handleBookmarkReorderOver(event, bookmarkItem);
+      return;
+    }
+
+    if (!folderHeader) return;
 
     const folderElement = folderHeader.closest(
       '.bookmark-folder'
@@ -271,18 +286,99 @@ export class BookmarkDragAndDrop {
   }
 
   /**
+   * ブックマーク間並び替えの dragover 処理 (#80)
+   *
+   * 上半分 → before, 下半分 → after で表示する。
+   * 自身へのドロップ、隣接 no-op はinvalid にする。
+   */
+  private handleBookmarkReorderOver(
+    event: DragEvent,
+    targetItem: HTMLElement
+  ): void {
+    if (!this.draggedBookmark) return;
+    const targetUrl = targetItem.getAttribute('data-bookmark-url');
+    if (!targetUrl) return;
+
+    // 自分自身へのドロップは無効
+    if (targetUrl === this.draggedBookmark.url) {
+      targetItem.classList.add('drop-target-invalid');
+      if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
+      return;
+    }
+
+    const rect = targetItem.getBoundingClientRect();
+    const zone =
+      event.clientY - rect.top < rect.height / 2 ? 'before' : 'after';
+
+    // 同じ親内 (= 同じ bookmark-list) で隣接 no-op を検出
+    const siblings = Array.from(
+      targetItem.parentElement?.querySelectorAll(':scope > .bookmark-item') ??
+        []
+    ) as HTMLElement[];
+    const srcItem = this.findBookmarkItemByUrl(this.draggedBookmark.url);
+    if (srcItem && siblings.includes(srcItem)) {
+      const srcIdx = siblings.indexOf(srcItem);
+      const tgtIdx = siblings.indexOf(targetItem);
+      if (zone === 'before' && srcIdx === tgtIdx - 1) {
+        targetItem.classList.add('drop-target-invalid');
+        if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
+        return;
+      }
+      if (zone === 'after' && srcIdx === tgtIdx + 1) {
+        targetItem.classList.add('drop-target-invalid');
+        if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
+        return;
+      }
+    }
+
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+
+    targetItem.classList.remove('drop-target-invalid');
+    if (zone === 'before') {
+      targetItem.classList.add('drop-zone-before');
+      targetItem.classList.remove('drop-zone-after');
+    } else {
+      targetItem.classList.add('drop-zone-after');
+      targetItem.classList.remove('drop-zone-before');
+    }
+  }
+
+  /**
+   * URL を data-bookmark-url とする bookmark-item 要素を探す
+   */
+  private findBookmarkItemByUrl(url: string): HTMLElement | null {
+    const items = document.querySelectorAll(
+      `.bookmark-item[data-bookmark-url]`
+    );
+    for (const el of Array.from(items)) {
+      if (el.getAttribute('data-bookmark-url') === url) {
+        return el as HTMLElement;
+      }
+    }
+    return null;
+  }
+
+  /**
    * ドラッグリーブ時の処理
    */
   private handleDragLeave(event: DragEvent): void {
     const target = event.target as HTMLElement;
     const folderHeader = target.closest('.folder-header') as HTMLElement;
-
     if (folderHeader) {
       folderHeader.classList.remove(
         'drop-target-highlight',
         'drop-target-invalid',
         'drop-zone-before',
         'drop-zone-after'
+      );
+    }
+    const bookmarkItem = target.closest('.bookmark-item') as HTMLElement | null;
+    if (bookmarkItem) {
+      bookmarkItem.classList.remove(
+        'drop-zone-before',
+        'drop-zone-after',
+        'drop-target-invalid'
       );
     }
   }
@@ -302,7 +398,18 @@ export class BookmarkDragAndDrop {
       return;
     }
 
-    if (!folderHeader || !this.draggedBookmark) return;
+    if (!this.draggedBookmark) return;
+
+    // ブックマーク間 reorder (#80)
+    const targetBookmarkItem = target.closest(
+      '.bookmark-item'
+    ) as HTMLElement | null;
+    if (targetBookmarkItem) {
+      this.handleBookmarkReorderDrop(event, targetBookmarkItem);
+      return;
+    }
+
+    if (!folderHeader) return;
 
     const folderElement = folderHeader.closest(
       '.bookmark-folder'
@@ -328,6 +435,107 @@ export class BookmarkDragAndDrop {
 
     // ハイライトを削除
     folderHeader.classList.remove('drop-target-highlight');
+  }
+
+  /**
+   * ブックマーク間 reorder の drop 処理 (#80)
+   */
+  private handleBookmarkReorderDrop(
+    event: DragEvent,
+    targetItem: HTMLElement
+  ): void {
+    if (!this.draggedBookmark) return;
+    const targetUrl = targetItem.getAttribute('data-bookmark-url');
+    if (!targetUrl || targetUrl === this.draggedBookmark.url) return;
+
+    const rect = targetItem.getBoundingClientRect();
+    const zone =
+      event.clientY - rect.top < rect.height / 2 ? 'before' : 'after';
+
+    targetItem.classList.remove(
+      'drop-zone-before',
+      'drop-zone-after',
+      'drop-target-invalid'
+    );
+
+    this.reorderBookmark(this.draggedBookmark.url, targetUrl, zone)
+      .then(() => {
+        this.refreshBookmarkList();
+      })
+      .catch((error) => {
+        console.error('ブックマーク並び替えエラー:', error);
+        alert('ブックマークの並び替えに失敗しました。');
+      });
+  }
+
+  /**
+   * 同じフォルダ (もしくは別フォルダ) 内でブックマークを並び替える。
+   * Undo に対応。Chrome の chrome.bookmarks.move の補正挙動 (#77 と同様) を考慮。
+   */
+  private async reorderBookmark(
+    sourceUrl: string,
+    targetUrl: string,
+    zone: 'before' | 'after'
+  ): Promise<void> {
+    try {
+      const [sources, targets] = await Promise.all([
+        chrome.bookmarks.search({ url: sourceUrl }),
+        chrome.bookmarks.search({ url: targetUrl }),
+      ]);
+      if (sources.length === 0)
+        throw new Error('ソースブックマークが見つかりません');
+      if (targets.length === 0)
+        throw new Error('ターゲットブックマークが見つかりません');
+
+      const source = sources[0];
+      const target = targets[0];
+      if (target.parentId === undefined) {
+        throw new Error('ターゲットの親が取得できません');
+      }
+      const originalParentId = source.parentId;
+      const originalIndex = source.index;
+      const sourceTitle = source.title;
+
+      const targetIndex = target.index ?? 0;
+      const newIndex = zone === 'before' ? targetIndex : targetIndex + 1;
+
+      await chrome.bookmarks.move(source.id, {
+        parentId: target.parentId,
+        index: newIndex,
+      });
+
+      if (originalParentId !== undefined) {
+        UndoManager.getInstance().register({
+          message: `「${sourceTitle}」を並び替えました`,
+          undo: async () => {
+            let undoIndex = originalIndex ?? 0;
+            try {
+              const [now] = await chrome.bookmarks.get(source.id);
+              if (
+                now?.parentId === originalParentId &&
+                now.index !== undefined &&
+                now.index < undoIndex
+              ) {
+                undoIndex = undoIndex + 1;
+              }
+            } catch {
+              // フォールバック
+            }
+            await chrome.bookmarks.move(source.id, {
+              parentId: originalParentId,
+              index: undoIndex,
+            });
+            const e = new CustomEvent('bookmarks-changed', {
+              detail: { action: 'undo-bookmark-reorder' },
+            });
+            document.dispatchEvent(e);
+          },
+        });
+      }
+    } catch (error) {
+      console.error('Chrome Bookmarks API エラー (reorder):', error);
+      throw error;
+    }
   }
 
   /**

--- a/src/styles.css
+++ b/src/styles.css
@@ -602,6 +602,38 @@ header h1 {
   bottom: -4px;
 }
 
+/* ブックマーク間並び替えのドロップ位置インジケータ (#80) */
+.bookmark-item.drop-zone-before,
+.bookmark-item.drop-zone-after {
+  position: relative;
+}
+
+.bookmark-item.drop-zone-before::before,
+.bookmark-item.drop-zone-after::after {
+  content: '';
+  position: absolute;
+  left: 4px;
+  right: 4px;
+  height: 3px;
+  background: var(--accent);
+  border-radius: 2px;
+  box-shadow: 0 0 8px var(--accent);
+  z-index: 2;
+}
+
+.bookmark-item.drop-zone-before::before {
+  top: -2px;
+}
+
+.bookmark-item.drop-zone-after::after {
+  bottom: -2px;
+}
+
+.bookmark-item.drop-target-invalid {
+  background-color: rgba(220, 38, 38, 0.08);
+  border-radius: var(--radius-sm);
+}
+
 /* ドラッグ中の元フォルダを薄く表示 */
 body.dragging-bookmark .bookmark-folder.drag-source-folder {
   opacity: 0.7;

--- a/test/bookmark-reorder.test.ts
+++ b/test/bookmark-reorder.test.ts
@@ -1,0 +1,263 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BookmarkDragAndDrop } from '../src/components/BookmarkDragAndDrop/index';
+import { Toast } from '../src/components/Toast/index';
+import { UndoManager } from '../src/components/UndoManager/index';
+
+/**
+ * ブックマーク間並び替え (#80) のテスト。
+ */
+describe('BookmarkDragAndDrop — ブックマーク間並び替え (#80)', () => {
+  let dom: JSDOM;
+  let dnd: BookmarkDragAndDrop;
+
+  function buildDom(): void {
+    document.body.innerHTML = `
+      <div class="bookmark-container">
+        <div class="bookmark-folder" data-folder-id="F">
+          <div class="folder-header"><h2>F</h2></div>
+          <ul class="bookmark-list">
+            <li class="bookmark-item" data-bookmark-url="https://a.example.com" data-bookmark-title="A">
+              <a class="bookmark-link" data-url="https://a.example.com"><span class="bookmark-title">A</span></a>
+            </li>
+            <li class="bookmark-item" data-bookmark-url="https://b.example.com" data-bookmark-title="B">
+              <a class="bookmark-link" data-url="https://b.example.com"><span class="bookmark-title">B</span></a>
+            </li>
+            <li class="bookmark-item" data-bookmark-url="https://c.example.com" data-bookmark-title="C">
+              <a class="bookmark-link" data-url="https://c.example.com"><span class="bookmark-title">C</span></a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    `;
+    // bookmark-item に rect を与える
+    for (const item of document.querySelectorAll('.bookmark-item')) {
+      const el = item as HTMLElement;
+      el.getBoundingClientRect = vi.fn(
+        () =>
+          ({
+            top: 0,
+            left: 0,
+            right: 200,
+            bottom: 40,
+            width: 200,
+            height: 40,
+            x: 0,
+            y: 0,
+            toJSON() {},
+          }) as DOMRect
+      );
+    }
+  }
+
+  function createDragEvent(
+    type: string,
+    target: HTMLElement,
+    clientY = 20
+  ): DragEvent {
+    const event = new dom.window.Event(type, {
+      bubbles: true,
+      cancelable: true,
+    }) as unknown as DragEvent;
+    Object.defineProperty(event, 'target', { value: target });
+    Object.defineProperty(event, 'clientY', { value: clientY });
+    Object.defineProperty(event, 'dataTransfer', {
+      value: {
+        setData: vi.fn(),
+        setDragImage: vi.fn(),
+        effectAllowed: '',
+        dropEffect: '',
+      },
+      writable: true,
+    });
+    return event;
+  }
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
+    (
+      dom.window as unknown as { requestAnimationFrame: () => number }
+    ).requestAnimationFrame = () => 0;
+    (
+      dom.window as unknown as { cancelAnimationFrame: () => void }
+    ).cancelAnimationFrame = () => {};
+    (dom.window as unknown as { scrollBy: () => void }).scrollBy = () => {};
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      value: (cb: () => void) => {
+        cb();
+        return 0;
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: {
+        search: ReturnType<typeof vi.fn>;
+        get: ReturnType<typeof vi.fn>;
+        move: ReturnType<typeof vi.fn>;
+      };
+    };
+    mockChrome.bookmarks.search = vi.fn().mockImplementation(({ url }) => {
+      if (url === 'https://a.example.com') {
+        return Promise.resolve([
+          {
+            id: 'a',
+            parentId: 'F',
+            index: 0,
+            title: 'A',
+            url,
+          },
+        ]);
+      }
+      if (url === 'https://b.example.com') {
+        return Promise.resolve([
+          { id: 'b', parentId: 'F', index: 1, title: 'B', url },
+        ]);
+      }
+      if (url === 'https://c.example.com') {
+        return Promise.resolve([
+          { id: 'c', parentId: 'F', index: 2, title: 'C', url },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    mockChrome.bookmarks.get = vi.fn().mockImplementation((id: string) => {
+      if (id === 'a')
+        return Promise.resolve([{ id: 'a', parentId: 'F', index: 0 }]);
+      if (id === 'b')
+        return Promise.resolve([{ id: 'b', parentId: 'F', index: 1 }]);
+      if (id === 'c')
+        return Promise.resolve([{ id: 'c', parentId: 'F', index: 2 }]);
+      return Promise.resolve([]);
+    });
+    mockChrome.bookmarks.move = vi.fn().mockResolvedValue(undefined);
+
+    buildDom();
+    dnd = new BookmarkDragAndDrop();
+    dnd.initialize();
+  });
+
+  afterEach(() => {
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  function dragStartFrom(url: string): void {
+    const link = document.querySelector(
+      `.bookmark-link[data-url="${url}"]`
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', link));
+  }
+
+  it('A を C の上半分にドロップ → move(a, {index: 2}) (Chrome側で -1 補正)', async () => {
+    dragStartFrom('https://a.example.com');
+
+    const targetItem = document.querySelector(
+      '[data-bookmark-url="https://c.example.com"]'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', targetItem, 10));
+    document.dispatchEvent(createDragEvent('drop', targetItem, 10));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('a', {
+      parentId: 'F',
+      index: 2,
+    });
+  });
+
+  it('C を A の下半分にドロップ → move(c, {index: 1})', async () => {
+    dragStartFrom('https://c.example.com');
+
+    const targetItem = document.querySelector(
+      '[data-bookmark-url="https://a.example.com"]'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', targetItem, 30));
+    document.dispatchEvent(createDragEvent('drop', targetItem, 30));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('c', {
+      parentId: 'F',
+      index: 1,
+    });
+  });
+
+  it('隣接 no-op (A → B の上半分) は drop-target-invalid', () => {
+    dragStartFrom('https://a.example.com');
+
+    const targetItem = document.querySelector(
+      '[data-bookmark-url="https://b.example.com"]'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', targetItem, 10));
+
+    expect(targetItem.classList.contains('drop-target-invalid')).toBe(true);
+    expect(targetItem.classList.contains('drop-zone-before')).toBe(false);
+  });
+
+  it('自分自身へのドロップは drop-target-invalid', () => {
+    dragStartFrom('https://a.example.com');
+
+    const selfItem = document.querySelector(
+      '[data-bookmark-url="https://a.example.com"]'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', selfItem, 10));
+
+    expect(selfItem.classList.contains('drop-target-invalid')).toBe(true);
+  });
+
+  it('Undo で元の位置に戻る (currentIdx < originalIndex のとき +1 補正)', async () => {
+    dragStartFrom('https://a.example.com');
+
+    const targetItem = document.querySelector(
+      '[data-bookmark-url="https://c.example.com"]'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', targetItem, 30));
+    document.dispatchEvent(createDragEvent('drop', targetItem, 30));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Undo 時、A の現在 index は 2 (forward 移動後) で original は 0
+    // currentIdx(2) > originalIndex(0) のため補正なし、undoIndex = 0
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: { get: ReturnType<typeof vi.fn> };
+    };
+    mockChrome.bookmarks.get.mockImplementation((id: string) => {
+      if (id === 'a')
+        return Promise.resolve([{ id: 'a', parentId: 'F', index: 2 }]);
+      return Promise.resolve([]);
+    });
+
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+    (toast?.querySelector('.app-toast-action') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(chrome.bookmarks.move).toHaveBeenLastCalledWith('a', {
+      parentId: 'F',
+      index: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
PR #79 (フォルダ並び替え) のパターンをブックマーク間にも展開し、フォルダ内のブックマーク順序を DnD で並び替え可能に。

### ゾーン判定
- ブックマーク item の **上半分**: `before` (target の前に挿入)
- **下半分**: `after` (target の後に挿入)

### 既存挙動との並存
- フォルダヘッダーへのドロップ = 別フォルダへ移動 (従来挙動)
- ブックマーク item へのドロップ = 同フォルダ内 (or 別フォルダ) 並び替え (新規)

### 視覚フィードバック
- accent カラーの線で挿入位置を表示
- 隣接 no-op (例: A 直後の B の上半分) と 自分自身へのドロップは `drop-target-invalid` で表示

### Undo
Chrome の `bookmarks.move` の `-1` 補正挙動を考慮し、`currentIdx < originalIndex` のとき `undoIndex + 1` で呼ぶ (PR #79 と同じパターン)。

## Test plan
- [x] `npm test` (253 tests passed)
- [x] `npm run lint`
- [x] `npm run format`
- [x] `npm run build:extension`
- [x] 実機: 同じフォルダ内でブックマークの上下を入れ替える
- [x] 実機: 別フォルダへの移動 (従来挙動) が壊れていない
- [x] 実機: Undo (Toast / Cmd+Z) で元の位置に戻る
- [x] 実機: 隣接ブックマークへの no-op ドロップは赤背景で示される

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)