### PR TITLE
ブックマーク一覧を masonry レイアウトに変更

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -242,10 +242,14 @@ header h1 {
 /* =========================================================================
    ブックマーク
    ========================================================================= */
+/*
+ * フォルダのカードは縦の高さがバラバラになるため、grid ではなく
+ * CSS multi-column (masonry 風) で詰める。column-width によりビューポート幅に
+ * 応じて自動的に列数が決まる。
+ */
 .bookmark-container {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));
-  gap: 25px;
+  column-width: 450px;
+  column-gap: 25px;
 }
 
 .bookmark-folder {
@@ -257,6 +261,14 @@ header h1 {
   transition: transform var(--transition), box-shadow var(--transition),
     border-color var(--transition);
   position: relative;
+  /* multi-column では各カードがカラムをまたがないように break-inside を指定 */
+  break-inside: avoid;
+  -webkit-column-break-inside: avoid;
+  page-break-inside: avoid;
+  /* カラム間に縦のリズムを出すための余白 */
+  margin-bottom: 25px;
+  /* display: block にして column 内で素直に積まれるようにする (デフォルトのまま) */
+  display: block;
 }
 
 .bookmark-folder:hover {
@@ -1424,7 +1436,9 @@ body.dragging-folder {
   }
 
   .bookmark-container {
-    grid-template-columns: 1fr;
+    /* 狭幅では強制的に 1 カラム */
+    column-count: 1;
+    column-width: auto;
   }
 
   .history-list {


### PR DESCRIPTION
## Summary
特定フォルダだけブックマーク数が多いと、CSS grid の行揃え制約で他カードの右に大きな空白ができ、画面の一覧性が損なわれていた。

CSS multi-column (masonry 風) に切り替えて、各カードを縦に詰める。

### Before
- `display: grid; grid-template-columns: repeat(auto-fit, minmax(450px, 1fr));`
- 各行の高さは最も背の高いカードに揃う → 短いカードの下に空白

### After
- `column-width: 450px; column-gap: 25px;`
- `.bookmark-folder { break-inside: avoid; margin-bottom: 25px; }`
- カード高さに関係なく空きスペースが詰められる

### 既知のトレードオフ
- DOM 順は維持される（並べ替えの結果は変わらない）が、視覚的には縦方向に流れるため、左カラム下→右カラム上 という読み順になる
- フォルダ DnD の "before / after" 並び替えは DOM 順に基づくため、視覚的な位置と完全には一致しないケースがある

### Responsive
狭幅 (モバイル幅) では `column-count: 1` で従来通り 1 列

## Test plan
- [x] `npm test` (253 tests passed)
- [x] `npm run build:extension`
- [ ] 実機: 1 つだけブックマーク多数のフォルダがある状況で空白が減ることを確認
- [ ] 実機: フォルダ DnD・編集・削除が引き続き動作することを確認
- [ ] 実機: ウィンドウ幅を変えてカラム数が自動調整されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)