### PR TITLE
DnD の複数選択一括移動とインジケータ残留を修正

### DIFF
--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -9,6 +9,11 @@ export class BookmarkDragAndDrop {
     url: string;
     title: string;
     originalFolderId: string;
+    /**
+     * 複数選択ドラッグの場合、ドラッグ対象のすべての URL リスト (本人含む)。
+     * 単一ドラッグなら [url] と同じになる。
+     */
+    additionalUrls: string[];
   } | null = null;
 
   private draggedFolder: {
@@ -78,10 +83,28 @@ export class BookmarkDragAndDrop {
 
     if (!url || !title || !folderId) return;
 
+    // ドラッグ対象が複数選択に含まれている場合、選択中の全ブックマークを対象にする
+    const sourceItem = bookmarkLink.closest(
+      '.bookmark-item'
+    ) as HTMLElement | null;
+    let additionalUrls: string[] = [url];
+    if (sourceItem?.classList.contains('selected')) {
+      const selectedItems = Array.from(
+        document.querySelectorAll('.bookmark-item.selected')
+      );
+      const urls = selectedItems
+        .map((el) => el.getAttribute('data-bookmark-url'))
+        .filter((u): u is string => typeof u === 'string');
+      if (urls.length > 1) {
+        additionalUrls = urls;
+      }
+    }
+
     this.draggedBookmark = {
       url,
       title,
       originalFolderId: folderId,
+      additionalUrls,
     };
 
     // ドラッグデータを設定
@@ -539,14 +562,78 @@ export class BookmarkDragAndDrop {
   }
 
   /**
-   * Chrome Bookmarks APIを使用してブックマークを移動する
+   * Chrome Bookmarks APIを使用してブックマークを移動する。
+   * draggedBookmark.additionalUrls に複数 URL が入っている場合は一括移動する。
    */
   private async moveBookmark(
     bookmarkUrl: string,
     targetFolderId: string
   ): Promise<void> {
+    const urls = this.draggedBookmark?.additionalUrls ?? [bookmarkUrl];
+
+    // 単一ドラッグ: 従来の挙動 (Undo: 単一)
+    if (urls.length <= 1) {
+      return this.moveSingleBookmark(bookmarkUrl, targetFolderId);
+    }
+
+    // 複数選択ドラッグ: すべて移動 (Undo: 一括)
+    return this.moveMultipleBookmarks(urls, targetFolderId);
+  }
+
+  private async moveMultipleBookmarks(
+    urls: string[],
+    targetFolderId: string
+  ): Promise<void> {
+    const moveInfos: {
+      id: string;
+      previousParentId: string | undefined;
+      previousIndex: number | undefined;
+      title: string;
+    }[] = [];
+
     try {
-      // 移動するブックマークを検索
+      for (const url of urls) {
+        const found = await chrome.bookmarks.search({ url });
+        if (found.length === 0) continue;
+        const target = found[0];
+        moveInfos.push({
+          id: target.id,
+          previousParentId: target.parentId,
+          previousIndex: target.index,
+          title: target.title,
+        });
+        await chrome.bookmarks.move(target.id, { parentId: targetFolderId });
+      }
+
+      if (moveInfos.length > 0) {
+        UndoManager.getInstance().register({
+          message: `${moveInfos.length} 件のブックマークを移動しました`,
+          undo: async () => {
+            for (const info of moveInfos) {
+              if (info.previousParentId === undefined) continue;
+              await chrome.bookmarks.move(info.id, {
+                parentId: info.previousParentId,
+                index: info.previousIndex,
+              });
+            }
+            const e = new CustomEvent('bookmarks-changed', {
+              detail: { action: 'undo-bulk-move' },
+            });
+            document.dispatchEvent(e);
+          },
+        });
+      }
+    } catch (error) {
+      console.error('Chrome Bookmarks API エラー (bulk move):', error);
+      throw error;
+    }
+  }
+
+  private async moveSingleBookmark(
+    bookmarkUrl: string,
+    targetFolderId: string
+  ): Promise<void> {
+    try {
       const bookmarks = await chrome.bookmarks.search({ url: bookmarkUrl });
 
       if (bookmarks.length === 0) {
@@ -558,7 +645,6 @@ export class BookmarkDragAndDrop {
       const originalIndex = bookmark.index;
       const bookmarkTitle = bookmark.title;
 
-      // ブックマークを移動
       await chrome.bookmarks.move(bookmark.id, {
         parentId: targetFolderId,
       });

--- a/src/components/BookmarkDragAndDrop/index.ts
+++ b/src/components/BookmarkDragAndDrop/index.ts
@@ -322,10 +322,21 @@ export class BookmarkDragAndDrop {
     const targetUrl = targetItem.getAttribute('data-bookmark-url');
     if (!targetUrl) return;
 
-    // 自分自身へのドロップは無効
-    if (targetUrl === this.draggedBookmark.url) {
+    // 前回の dragover で付けたインジケータ/invalid を毎回クリアして付け直す
+    targetItem.classList.remove(
+      'drop-zone-before',
+      'drop-zone-after',
+      'drop-target-invalid'
+    );
+
+    const markInvalid = () => {
       targetItem.classList.add('drop-target-invalid');
       if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
+    };
+
+    // 自分自身へのドロップは無効
+    if (targetUrl === this.draggedBookmark.url) {
+      markInvalid();
       return;
     }
 
@@ -343,13 +354,11 @@ export class BookmarkDragAndDrop {
       const srcIdx = siblings.indexOf(srcItem);
       const tgtIdx = siblings.indexOf(targetItem);
       if (zone === 'before' && srcIdx === tgtIdx - 1) {
-        targetItem.classList.add('drop-target-invalid');
-        if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
+        markInvalid();
         return;
       }
       if (zone === 'after' && srcIdx === tgtIdx + 1) {
-        targetItem.classList.add('drop-target-invalid');
-        if (event.dataTransfer) event.dataTransfer.dropEffect = 'none';
+        markInvalid();
         return;
       }
     }
@@ -357,14 +366,9 @@ export class BookmarkDragAndDrop {
     event.preventDefault();
     if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
 
-    targetItem.classList.remove('drop-target-invalid');
-    if (zone === 'before') {
-      targetItem.classList.add('drop-zone-before');
-      targetItem.classList.remove('drop-zone-after');
-    } else {
-      targetItem.classList.add('drop-zone-after');
-      targetItem.classList.remove('drop-zone-before');
-    }
+    targetItem.classList.add(
+      zone === 'before' ? 'drop-zone-before' : 'drop-zone-after'
+    );
   }
 
   /**
@@ -868,8 +872,13 @@ export class BookmarkDragAndDrop {
         ? this.isInvalidFolderDropTarget(sourceElement, targetFolderElement)
         : this.isInvalidFolderReorder(sourceElement, targetFolderElement, zone);
 
-    // 既存の reorder インジケータと invalid クラスをクリア
-    folderHeader.classList.remove('drop-zone-before', 'drop-zone-after');
+    // 前回の dragover で付けたインジケータ・invalid クラスを毎回クリアしてから付け直す
+    folderHeader.classList.remove(
+      'drop-zone-before',
+      'drop-zone-after',
+      'drop-target-highlight',
+      'drop-target-invalid'
+    );
 
     if (invalid) {
       folderHeader.classList.add('drop-target-invalid');
@@ -887,7 +896,6 @@ export class BookmarkDragAndDrop {
     if (zone === 'into') {
       folderHeader.classList.add('drop-target-highlight');
     } else {
-      folderHeader.classList.remove('drop-target-highlight');
       folderHeader.classList.add(
         zone === 'before' ? 'drop-zone-before' : 'drop-zone-after'
       );

--- a/test/bookmark-multi-drag.test.ts
+++ b/test/bookmark-multi-drag.test.ts
@@ -1,0 +1,215 @@
+import { JSDOM } from 'jsdom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BookmarkDragAndDrop } from '../src/components/BookmarkDragAndDrop/index';
+import { Toast } from '../src/components/Toast/index';
+import { UndoManager } from '../src/components/UndoManager/index';
+
+/**
+ * 複数選択ブックマークの DnD 移動テスト (#?)
+ * Multi-select + drag → drop on another folder header で全件移動されること。
+ */
+describe('BookmarkDragAndDrop — 複数選択ドラッグでの一括移動', () => {
+  let dom: JSDOM;
+  let dnd: BookmarkDragAndDrop;
+
+  function buildDom(): void {
+    document.body.innerHTML = `
+      <div class="bookmark-container">
+        <div class="bookmark-folder" data-folder-id="src">
+          <div class="folder-header"><h2>src</h2></div>
+          <ul class="bookmark-list">
+            <li class="bookmark-item selected" data-bookmark-url="https://a.example.com" data-bookmark-title="A">
+              <a class="bookmark-link" data-url="https://a.example.com"><span class="bookmark-title">A</span></a>
+            </li>
+            <li class="bookmark-item selected" data-bookmark-url="https://b.example.com" data-bookmark-title="B">
+              <a class="bookmark-link" data-url="https://b.example.com"><span class="bookmark-title">B</span></a>
+            </li>
+            <li class="bookmark-item" data-bookmark-url="https://c.example.com" data-bookmark-title="C">
+              <a class="bookmark-link" data-url="https://c.example.com"><span class="bookmark-title">C</span></a>
+            </li>
+          </ul>
+        </div>
+        <div class="bookmark-folder" data-folder-id="dst">
+          <div class="folder-header"><h2>dst</h2></div>
+        </div>
+      </div>
+    `;
+  }
+
+  function createDragEvent(type: string, target: HTMLElement): DragEvent {
+    const event = new dom.window.Event(type, {
+      bubbles: true,
+      cancelable: true,
+    }) as unknown as DragEvent;
+    Object.defineProperty(event, 'target', { value: target });
+    Object.defineProperty(event, 'dataTransfer', {
+      value: {
+        setData: vi.fn(),
+        setDragImage: vi.fn(),
+        effectAllowed: '',
+        dropEffect: '',
+      },
+      writable: true,
+    });
+    return event;
+  }
+
+  beforeEach(() => {
+    dom = new JSDOM(`<!DOCTYPE html><html><body></body></html>`);
+    (
+      dom.window as unknown as { requestAnimationFrame: () => number }
+    ).requestAnimationFrame = () => 0;
+    (
+      dom.window as unknown as { cancelAnimationFrame: () => void }
+    ).cancelAnimationFrame = () => {};
+    (dom.window as unknown as { scrollBy: () => void }).scrollBy = () => {};
+
+    Object.defineProperty(globalThis, 'document', {
+      value: dom.window.document,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: dom.window,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'CustomEvent', {
+      value: dom.window.CustomEvent,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'requestAnimationFrame', {
+      value: (cb: () => void) => {
+        cb();
+        return 0;
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: {
+        search: ReturnType<typeof vi.fn>;
+        move: ReturnType<typeof vi.fn>;
+      };
+    };
+    mockChrome.bookmarks.search = vi.fn().mockImplementation(({ url }) => {
+      if (url === 'https://a.example.com') {
+        return Promise.resolve([
+          { id: 'a', parentId: 'src', index: 0, title: 'A', url },
+        ]);
+      }
+      if (url === 'https://b.example.com') {
+        return Promise.resolve([
+          { id: 'b', parentId: 'src', index: 1, title: 'B', url },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    mockChrome.bookmarks.move = vi.fn().mockResolvedValue(undefined);
+
+    buildDom();
+    dnd = new BookmarkDragAndDrop();
+    dnd.initialize();
+  });
+
+  afterEach(() => {
+    UndoManager.getInstance().clear();
+    Toast.dismissCurrent();
+    dom.window.close();
+    vi.clearAllMocks();
+  });
+
+  it('選択中の項目をドラッグすると、選択中の全件が dst へ move される', async () => {
+    // ドラッグ元: A (.selected の 1 つ)
+    const link = document.querySelector(
+      '.bookmark-link[data-url="https://a.example.com"]'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', link));
+
+    const folderHeader = document.querySelector(
+      '[data-folder-id="dst"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', folderHeader));
+    document.dispatchEvent(createDragEvent('drop', folderHeader));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // A と B の両方が move される
+    expect(chrome.bookmarks.move).toHaveBeenCalledTimes(2);
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('a', {
+      parentId: 'dst',
+    });
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('b', {
+      parentId: 'dst',
+    });
+  });
+
+  it('一括移動後に Undo Toast が表示され、Undo で元の位置に戻る', async () => {
+    const link = document.querySelector(
+      '.bookmark-link[data-url="https://a.example.com"]'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragstart', link));
+
+    const folderHeader = document.querySelector(
+      '[data-folder-id="dst"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', folderHeader));
+    document.dispatchEvent(createDragEvent('drop', folderHeader));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    const toast = document.querySelector('.app-toast');
+    expect(toast).not.toBeNull();
+    expect(toast?.textContent).toContain('2 件のブックマークを移動しました');
+
+    (toast?.querySelector('.app-toast-action') as HTMLButtonElement).click();
+    await new Promise((r) => setTimeout(r, 30));
+
+    // 元の親 (src) + 元の index へ戻す move が 2 件呼ばれる
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('a', {
+      parentId: 'src',
+      index: 0,
+    });
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('b', {
+      parentId: 'src',
+      index: 1,
+    });
+  });
+
+  it('選択されていない項目のドラッグは単一移動 (従来挙動)', async () => {
+    // C は .selected なし
+    const link = document.querySelector(
+      '.bookmark-link[data-url="https://c.example.com"]'
+    ) as HTMLElement;
+    const mockChrome = globalThis.chrome as unknown as {
+      bookmarks: { search: ReturnType<typeof vi.fn> };
+    };
+    mockChrome.bookmarks.search.mockImplementation(({ url }) => {
+      if (url === 'https://c.example.com') {
+        return Promise.resolve([
+          { id: 'c', parentId: 'src', index: 2, title: 'C', url },
+        ]);
+      }
+      return Promise.resolve([]);
+    });
+    document.dispatchEvent(createDragEvent('dragstart', link));
+
+    const folderHeader = document.querySelector(
+      '[data-folder-id="dst"] .folder-header'
+    ) as HTMLElement;
+    document.dispatchEvent(createDragEvent('dragover', folderHeader));
+    document.dispatchEvent(createDragEvent('drop', folderHeader));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(chrome.bookmarks.move).toHaveBeenCalledTimes(1);
+    expect(chrome.bookmarks.move).toHaveBeenCalledWith('c', {
+      parentId: 'dst',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
PR #84 (内部 2 カラム表示) から、緊急度の高い DnD 関連の 2 件のバグ修正だけを切り出した PR。

### 1. 複数選択ドラッグで全件が移動されない
multi-select 状態でブックマークをドラッグしても、ドラッグ起点 1 件しか移動されていなかった。
- `handleDragStart`: ドラッグ元が `.selected` を持つ場合、選択中の全 URL を `additionalUrls` に格納
- `moveBookmark`: 複数 URL があれば `moveMultipleBookmarks` で順次移動
- Undo は一括 Undo として登録 (`N 件のブックマークを移動しました`)
- 単一選択は従来挙動

### 2. DnD インジケータの残留 (赤破線残り)
dragover が連続発火する間に無効ゾーン→有効ゾーンへ移動した際、`drop-target-invalid` が残ったまま `drop-zone-before/after` も追加され、赤破線が表示されたままになっていた。
- `handleFolderDragOver` と `handleBookmarkReorderOver` で毎回関連クラスを全てクリアしてから付け直し

## Test plan
- [x] `npm test` (256 tests passed)
- [x] `npm run build:extension`
- [ ] 実機: multi-select でドラッグ → 全件移動
- [ ] 実機: フォルダドラッグで赤破線が残らない

🤖 Generated with [Claude Code](https://claude.com/claude-code)