### PR TITLE
biome の lint/format から生成物を除外 (Closes #93)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,7 +22,15 @@
     }
   },
   "files": {
-    "includes": ["**/src/**/*.ts", "**/test/**/*.ts", "**/*.ts", "**/*.js"]
+    "includes": [
+      "**/src/**/*.ts",
+      "**/test/**/*.ts",
+      "**/*.ts",
+      "**/*.js",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/coverage"
+    ]
   },
   "overrides": [
     {


### PR DESCRIPTION
## 概要

Issue #93 の対応。`biome.json` の `files.includes` が `**/*.js` を含むため、生成物 `coverage/`（istanbul）と `dist/`（tsc 出力）の生成 JS まで lint/format 対象になっていた。ローカルで生成物が存在する状態だと `npm run lint` / `npm run format` が大量の誤指摘で赤くなり、本来の指摘が埋もれていた。

## 変更

`files.includes` に生成物ディレクトリの除外を追加（biome 推奨のフォルダ無視形式 `!**/dist` 等を使用）:

```json
"includes": [
  "**/src/**/*.ts",
  "**/test/**/*.ts",
  "**/*.ts",
  "**/*.js",
  "!**/node_modules",
  "!**/dist",
  "!**/coverage"
]
```

追跡対象の `.js` ファイルは存在しない（全て生成物 or node_modules）ことを確認済みのため、`**/*.js` を残しつつ生成物のみ除外する形にした。

## 検証

生成物を生成した状態でもクリーンに通ることを確認:

```
npm run test:coverage   # coverage/ 生成 (6 *.js)
npm run build:extension # dist/ 生成 (38 *.js)
npm run lint            # Checked 72 files, exit 0, warning 0
npm run format          # Checked 72 files, exit 0
```

- src/test は引き続き lint/format 対象（誤って除外していないことを確認）
- `npm test`: 256 passed / `npx tsc --noEmit`: OK / `npm run build:extension`: 成功

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)
